### PR TITLE
Async requests

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -22,7 +22,6 @@ extern UINT32 GlobalLogLevel = 0;
 
 extern PGLOBAL_INFORMATION GlobalInformation;
 
-_Use_decl_annotations_
 BOOLEAN
 WNBDReadRegistryValue(PUNICODE_STRING RegistryPath,
                       PWSTR Key,

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -18,7 +18,6 @@
 #define WNBD_INQUIRY_PRODUCT_REVISION    "V0.1"
 #define WNBD_INQUIRY_VENDOR_SPECIFIC     "WNBD_DISK_SPECIFIC_VENDOR_STRING"
 
-_Use_decl_annotations_
 BOOLEAN
 WNBDReadRegistryValue(_In_ PUNICODE_STRING RegistryPath,
                       _In_ PWSTR Key,

--- a/driver/driver_extension.c
+++ b/driver/driver_extension.c
@@ -36,6 +36,7 @@ WnbdInitializeGlobalInformation(PVOID Handle,
     InitializeListHead(&Info->ConnectionList);
     if (!NT_SUCCESS(ExInitializeResourceLite(&Info->ConnectionMutex))) {
         WNBD_LOG_ERROR(": Error allocating Info->ConnectionMutex");
+        ExFreePool(Info);
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 

--- a/driver/driver_extension.h
+++ b/driver/driver_extension.h
@@ -21,6 +21,7 @@ typedef struct _PGLOBAL_INFORMATION
 
 VOID
 WnbdDeleteGlobalInformation(_Inout_ PVOID PGlobalInformation);
+#pragma alloc_text (PAGE, WnbdDeleteGlobalInformation)
 
 NTSTATUS
 WnbdInitializeGlobalInformation(_In_ PVOID Handle,

--- a/driver/rbd_protocol.c
+++ b/driver/rbd_protocol.c
@@ -271,7 +271,8 @@ RbdNegotiate(_In_ INT* Pfd,
 
             case NBD_REP_ERR_POLICY:
                 if (Reply->Datasize > 0) {
-                    Reply->Data[255] = '\0';
+                    // Ugly hack to make the log message null terminated
+                    Reply->Data[Reply->Datasize -1] = '\0';
                     WNBD_LOG_ERROR("Connection not allowed by server policy. Server said: %s", Reply->Data);
                 } else {
                     WNBD_LOG_ERROR("Connection not allowed by server policy.");
@@ -281,7 +282,8 @@ RbdNegotiate(_In_ INT* Pfd,
 
             default:
                 if (Reply->Datasize > 0) {
-                    Reply->Data[255] = '\0';
+                    // Ugly hack to make the log message null terminated
+                    Reply->Data[Reply->Datasize - 1] = '\0';
                     WNBD_LOG_INFO("Unknown error returned by server. Server said: %s", Reply->Data);
                 }
                 else {

--- a/driver/scsi_driver_extensions.c
+++ b/driver/scsi_driver_extensions.c
@@ -113,7 +113,10 @@ WnbdHwFindAdapter(PVOID DeviceExtension,
     /*
      * https://docs.microsoft.com/en-us/previous-versions/windows/hardware/drivers/ff563901(v%3Dvs.85)
      */
-    ConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;
+    // We're receiving 0 lengths for SCSIOP_READ|SCSIOP_WRITE when setting
+    // MaximumTransferLength to SP_UNINITIALIZED_VALUE. Keeping transfer lengths
+    // smaller than 32MB avoids this issue.
+    ConfigInfo->MaximumTransferLength = WNBD_MAX_TRANSFER_LENGTH;
     ConfigInfo->NumberOfPhysicalBreaks = SP_UNINITIALIZED_VALUE;
     ConfigInfo->AlignmentMask = FILE_BYTE_ALIGNMENT;
     ConfigInfo->NumberOfBuses = MAX_NUMBER_OF_SCSI_BUSES;

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -14,11 +14,92 @@
 #include "util.h"
 #include "userspace.h"
 
-UCHAR DrainDeviceQueue(PVOID DeviceExtension,
-                       PSCSI_REQUEST_BLOCK Srb)
+_Use_decl_annotations_
+VOID WnbdReleaseSemaphore(PKSEMAPHORE RequestSemaphore,
+                          KPRIORITY Increment,
+                          LONG Adjustment,
+                          BOOLEAN Wait)
+{
+    WNBD_LOG_LOUD(": Enter");
+    /* STATUS_SEMAPHORE_LIMIT_EXCEEDED, can be raised.
+     * https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kereleasesemaphore */
+    __try
+    {
+        KeReleaseSemaphore(RequestSemaphore, Increment, Adjustment, Wait);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        WNBD_LOG_ERROR("RequestSemaphore failed with status: %x", GetExceptionCode());
+    }
+    WNBD_LOG_LOUD(": Exit");
+}
+
+VOID DrainDeviceQueue(PWNBD_SCSI_DEVICE Device, PLIST_ENTRY ListHead,
+                      PKSPIN_LOCK ListLock, PSCSI_DEVICE_INFORMATION DeviceInformation)
+{
+    WNBD_LOG_LOUD(": Enter");
+
+    PLIST_ENTRY Request;
+    PSRB_QUEUE_ELEMENT Element;
+
+    while ((Request = ExInterlockedRemoveHeadList(ListHead, ListLock)) != NULL) {
+        Element = CONTAINING_RECORD(Request, SRB_QUEUE_ELEMENT, Link);
+
+        Element->Srb->DataTransferLength = 0;
+        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
+        Element->Aborted = 1;
+
+        InterlockedDecrement(&Device->OutstandingIoCount);
+        WNBD_LOG_INFO("Notifying StorPort of completion of %p 0x%llx status: 0x%x(%s)",
+            Element->Srb, Element->Tag, Element->Srb->SrbStatus,
+            WnbdToStringSrbStatus(Element->Srb->SrbStatus));
+        StorPortNotification(RequestComplete, Element->DeviceExtension,
+                             Element->Srb);
+        ExFreePool(Element);
+
+        WnbdReleaseSemaphore(&DeviceInformation->RequestSemaphore, 0, 1, FALSE);
+    }
+}
+
+
+VOID SendAbortFailedForQueue(PLIST_ENTRY ListHead, PKSPIN_LOCK ListLock,
+                             PSCSI_DEVICE_INFORMATION DeviceInformation)
+{
+    WNBD_LOG_LOUD(": Enter");
+
+    PSRB_QUEUE_ELEMENT Element;
+    PLIST_ENTRY ItemLink, ItemNext;
+    KIRQL Irql = { 0 };
+
+    KeAcquireSpinLock(ListLock, &Irql);
+    LIST_FORALL_SAFE(ListHead, ItemLink, ItemNext) {
+        Element = CONTAINING_RECORD(ItemLink, SRB_QUEUE_ELEMENT, Link);
+
+        Element->Srb->DataTransferLength = 0;
+        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
+
+        // If it's marked as aborted, it means that Storport was already notified.
+        // Double completion leads to a crash.
+        if(!Element->Aborted) {
+            WNBD_LOG_INFO("Notifying StorPort of completion of %p 0x%llx status: 0x%x(%s)",
+            Element->Srb, Element->Tag, Element->Srb->SrbStatus,
+            WnbdToStringSrbStatus(Element->Srb->SrbStatus));
+            StorPortNotification(RequestComplete, Element->DeviceExtension,
+                                 Element->Srb);
+            Element->Aborted = 1;
+
+            // TODO: should we release the semaphore for aborted but still pending requests?
+            WnbdReleaseSemaphore(&DeviceInformation->RequestSemaphore, 0, 1, FALSE);
+        }
+    }
+    KeReleaseSpinLock(ListLock, Irql);
+}
+
+UCHAR DrainDeviceQueues(PVOID DeviceExtension,
+                        PSCSI_REQUEST_BLOCK Srb)
 
 {
-    WNBD_LOG_ERROR(": Enter");
+    WNBD_LOG_LOUD(": Enter");
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
@@ -60,26 +141,21 @@ UCHAR DrainDeviceQueue(PVOID DeviceExtension,
         goto Exit;
     }
     if (Device->Missing) {
+        PSCSI_DEVICE_INFORMATION Info = (PSCSI_DEVICE_INFORMATION)Device->ScsiDeviceExtension;
         WNBD_LOG_WARN("%p is marked for deletion. PathId = %d. TargetId = %d. LUN = %d",
             Device, Srb->PathId, Srb->TargetId, Srb->Lun);
+        /// Drain the queue here because the device doesn't theoretically exist;
+        DrainDeviceQueue(Device, &Info->RequestListHead, &Info->RequestListLock, Info);
+        DrainDeviceQueue(Device, &Info->ReplyListHead, &Info->ReplyListLock, Info);
         goto Exit;
     }
     PSCSI_DEVICE_INFORMATION Info = (PSCSI_DEVICE_INFORMATION)Device->ScsiDeviceExtension;
-    PLIST_ENTRY Request;
-    PSRB_QUEUE_ELEMENT Element;
 
-    while ((Request = ExInterlockedRemoveHeadList(&Info->ListHead, &Info->ListLock)) != NULL) {
-        Element = CONTAINING_RECORD(Request, SRB_QUEUE_ELEMENT, Link);
-
-        Element->Srb->DataTransferLength = 0;
-        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
-
-        InterlockedDecrement(&Device->OutstandingIoCount);
-        WNBD_LOG_INFO("Notifying StorPort of completion of %p status: 0x%x(%s)",
-            Element->Srb, Element->Srb->SrbStatus, WnbdToStringSrbStatus(Element->Srb->SrbStatus));
-        StorPortNotification(RequestComplete, Element->DeviceExtension, Element->Srb);
-        ExFreePool(Element);
-    }
+    DrainDeviceQueue(Device, &Info->RequestListHead, &Info->RequestListLock, Info);
+    // Should we set those in-flight requests to SRB_STATUS_ABORT_FAILED?
+    // We can't set them to SRB_STATUS_ABORTED because those requests have been
+    // submitted and will most probably complete.
+    SendAbortFailedForQueue(&Info->ReplyListHead, &Info->ReplyListLock, Info);
 
     SrbStatus = SRB_STATUS_SUCCESS;
 
@@ -100,7 +176,7 @@ WnbdAbortFunction(_In_ PVOID DeviceExtension,
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
-    UCHAR SrbStatus = DrainDeviceQueue(DeviceExtension, Srb);
+    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
 
     WNBD_LOG_LOUD(": Exit");
 
@@ -117,7 +193,7 @@ WnbdResetLogicalUnitFunction(PVOID DeviceExtension,
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
-    UCHAR SrbStatus = DrainDeviceQueue(DeviceExtension, Srb);
+    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
 
     WNBD_LOG_LOUD(": Exit");
 

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -57,6 +57,8 @@ VOID DrainDeviceQueue(PWNBD_SCSI_DEVICE Device, PLIST_ENTRY ListHead,
                              Element->Srb);
         ExFreePool(Element);
 
+        InterlockedIncrement64(&DeviceInformation->Stats.AbortedUnsubmittedIORequests);
+
         WnbdReleaseSemaphore(&DeviceInformation->RequestSemaphore, 0, 1, FALSE);
     }
 }
@@ -87,6 +89,8 @@ VOID SendAbortFailedForQueue(PLIST_ENTRY ListHead, PKSPIN_LOCK ListLock,
             StorPortNotification(RequestComplete, Element->DeviceExtension,
                                  Element->Srb);
             Element->Aborted = 1;
+
+            InterlockedIncrement64(&DeviceInformation->Stats.AbortedUnsubmittedIORequests);
 
             // TODO: should we release the semaphore for aborted but still pending requests?
             WnbdReleaseSemaphore(&DeviceInformation->RequestSemaphore, 0, 1, FALSE);

--- a/driver/scsi_function.h
+++ b/driver/scsi_function.h
@@ -29,4 +29,9 @@ WnbdExecuteScsiFunction(_In_ PVOID DeviceExtension,
 UCHAR
 WnbdPNPFunction(_In_ PSCSI_REQUEST_BLOCK Srb);
 
+VOID WnbdReleaseSemaphore(_In_ PKSEMAPHORE RequestSemaphore,
+                          _In_ KPRIORITY Increment,
+                          _In_ LONG Adjustment,
+                          _In_ _Literal_ BOOLEAN Wait);
+
 #endif

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "debug.h"
 #include "scsi_operation.h"
+#include "scsi_function.h"
 #include "scsi_trace.h"
 #include "srb_helper.h"
 #include "userspace.h"
@@ -338,6 +339,7 @@ WnbdPendElement(_In_ PVOID DeviceExtension,
     WNBD_LOG_LOUD(": Enter");
     NTSTATUS Status = STATUS_SUCCESS;
     PSCSI_DEVICE_INFORMATION ScsiInfo = (PSCSI_DEVICE_INFORMATION)ScsiDeviceExtension;
+
     PSRB_QUEUE_ELEMENT Element = (PSRB_QUEUE_ELEMENT)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(SRB_QUEUE_ELEMENT), 'DBNs');
     if (NULL == Element) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -350,9 +352,9 @@ WnbdPendElement(_In_ PVOID DeviceExtension,
     Element->Srb = Srb;
     Element->StartingLbn = StartingLbn;
     Element->ReadLength = (ULONG)DataLength;
-    ExInterlockedInsertTailList(&ScsiInfo->ListHead, &Element->Link, &ScsiInfo->ListLock);
-
-    KeSetEvent(&ScsiInfo->DeviceEvent, (KPRIORITY)0, FALSE);
+    Element->Aborted = 0;
+    ExInterlockedInsertTailList(&ScsiInfo->RequestListHead, &Element->Link, &ScsiInfo->RequestListLock);
+    WnbdReleaseSemaphore(&ScsiInfo->DeviceEvent, 0, 1, FALSE);
     Status = STATUS_PENDING;
 
 Exit:
@@ -392,6 +394,13 @@ WnbdPendOperation(_In_ PVOID DeviceExtension,
         UINT32 Access = 0;
         SrbCdbGetRange(Cdb, &BlockAddress, &BlockCount, &Access);
         DataLength = BlockCount * ScsiInfo->UserEntry->BlockSize;
+        if (DataLength < Srb->DataTransferLength &&
+            (Cdb->AsByte[0] != SCSIOP_SYNCHRONIZE_CACHE || Cdb->AsByte[0] != SCSIOP_SYNCHRONIZE_CACHE16)) {
+            WNBD_LOG_ERROR("STATUS_BUFFER_TOO_SMALL");
+            Srb->SrbStatus = SRB_STATUS_ABORTED;
+            Status = STATUS_BUFFER_TOO_SMALL;
+            break;
+        }
         Status = WnbdPendElement(DeviceExtension, ScsiDeviceExtension, Srb,
             BlockAddress * ScsiInfo->UserEntry->BlockSize, DataLength);
         }
@@ -420,13 +429,13 @@ WnbdHandleSrbOperation(PVOID DeviceExtension,
     PCDB Cdb = (PCDB) &Srb->Cdb;
     NTSTATUS status = STATUS_SUCCESS;
     PSCSI_DEVICE_INFORMATION Info = (PSCSI_DEVICE_INFORMATION)ScsiDeviceExtension;
-    UINT16 BlockSize = Info->UserEntry->BlockSize;
-    UINT64 BlockCount = WnbdGetBlockCount(Info->UserEntry->DiskSize, BlockSize);
-
-    if (Info->SoftTerminateDevice || Info->HardTerminateDevice) {
+    if (!Info || !Info->UserEntry || Info->SoftTerminateDevice || Info->HardTerminateDevice) {
         Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
         return status;
     }
+    UINT16 BlockSize = Info->UserEntry->BlockSize;
+    UINT64 BlockCount = WnbdGetBlockCount(Info->UserEntry->DiskSize, BlockSize);
+
 
     WNBD_LOG_LOUD("Processing %s command",
                   WnbdToStringSrbCdbOperation(Cdb->AsByte[0]));

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -340,6 +340,9 @@ WnbdPendElement(_In_ PVOID DeviceExtension,
     NTSTATUS Status = STATUS_SUCCESS;
     PSCSI_DEVICE_INFORMATION ScsiInfo = (PSCSI_DEVICE_INFORMATION)ScsiDeviceExtension;
 
+    InterlockedIncrement64(&ScsiInfo->Stats.TotalReceivedIORequests);
+    InterlockedIncrement64(&ScsiInfo->Stats.UnsubmittedIORequests);
+
     PSRB_QUEUE_ELEMENT Element = (PSRB_QUEUE_ELEMENT)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(SRB_QUEUE_ELEMENT), 'DBNs');
     if (NULL == Element) {
         Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -10,6 +10,7 @@
 #include "debug.h"
 #include "driver_extension.h"
 #include "rbd_protocol.h"
+#include "scsi_function.h"
 #include "userspace.h"
 #include "util.h"
 
@@ -145,42 +146,88 @@ WnbdSetInquiryData(_Inout_ PINQUIRYDATA InquiryData)
     WNBD_LOG_LOUD(": Exit");
 }
 
+#define MallocT(S) ExAllocatePoolWithTag(NonPagedPoolNx, S, 'pDBR')
+
 NTSTATUS
 WnbdInitializeScsiInfo(_In_ PSCSI_DEVICE_INFORMATION ScsiInfo)
 {
     WNBD_LOG_LOUD(": Enter");
     ASSERT(ScsiInfo);
-    HANDLE thread_handle;
+    HANDLE request_thread_handle = NULL, reply_thread_handle = NULL;
     NTSTATUS Status = STATUS_SUCCESS;
 
-    InitializeListHead(&ScsiInfo->ListHead);
-    KeInitializeSpinLock(&ScsiInfo->ListLock);
-    KeInitializeEvent(&ScsiInfo->DeviceEvent, SynchronizationEvent, FALSE);
-
-    ScsiInfo->HardTerminateDevice = FALSE;
-    ScsiInfo->SoftTerminateDevice = FALSE;
-
-    Status = PsCreateSystemThread(&thread_handle, (ACCESS_MASK)0L, NULL, NULL, NULL, WnbdDeviceThread, ScsiInfo);
-
+    InitializeListHead(&ScsiInfo->RequestListHead);
+    KeInitializeSpinLock(&ScsiInfo->RequestListLock);
+    KeInitializeSemaphore(&ScsiInfo->RequestSemaphore,
+                          WNBD_MAX_IN_FLIGHT_REQUESTS,
+                          WNBD_MAX_IN_FLIGHT_REQUESTS);
+    InitializeListHead(&ScsiInfo->ReplyListHead);
+    KeInitializeSpinLock(&ScsiInfo->ReplyListLock);
+    KeInitializeSemaphore(&ScsiInfo->DeviceEvent, 0, 1 << 30);
+    Status = ExInitializeResourceLite(&ScsiInfo->SocketLock);
     if (!NT_SUCCESS(Status)) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Exit;
     }
 
-    Status = ObReferenceObjectByHandle(thread_handle, THREAD_ALL_ACCESS, NULL, KernelMode,
-        &ScsiInfo->DeviceThread, NULL);
-
-    if (!NT_SUCCESS(Status)) {
-        ZwClose(thread_handle);
-        ScsiInfo->SoftTerminateDevice = TRUE;
-        KeSetEvent(&ScsiInfo->DeviceEvent, (KPRIORITY)0, FALSE);
+    ScsiInfo->HardTerminateDevice = FALSE;
+    ScsiInfo->SoftTerminateDevice = FALSE;
+    ScsiInfo->ReadPreallocatedBuffer = MallocT(((UINT)WNBD_PREALLOC_BUFF_SZ));
+    if (!ScsiInfo->ReadPreallocatedBuffer) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Exit;
+    }
+    ScsiInfo->ReadPreallocatedBufferLength = WNBD_PREALLOC_BUFF_SZ;
+    ScsiInfo->WritePreallocatedBuffer = MallocT(((UINT)WNBD_PREALLOC_BUFF_SZ));
+    if (!ScsiInfo->WritePreallocatedBuffer) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Exit;
+    }
+    ScsiInfo->WritePreallocatedBufferLength = WNBD_PREALLOC_BUFF_SZ;
+
+    Status = PsCreateSystemThread(&request_thread_handle, (ACCESS_MASK)0L, NULL,
+                                  NULL, NULL, WnbdDeviceRequestThread, ScsiInfo);
+    if (!NT_SUCCESS(Status)) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Exit;
+    }
+
+    Status = ObReferenceObjectByHandle(request_thread_handle, THREAD_ALL_ACCESS, NULL, KernelMode,
+        &ScsiInfo->DeviceRequestThread, NULL);
+
+    if (!NT_SUCCESS(Status)) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto SoftTerminate;
+    }
+
+    Status = PsCreateSystemThread(&reply_thread_handle, (ACCESS_MASK)0L, NULL,
+                                  NULL, NULL, WnbdDeviceReplyThread, ScsiInfo);
+    if (!NT_SUCCESS(Status)) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto SoftTerminate;
+    }
+
+    Status = ObReferenceObjectByHandle(reply_thread_handle, THREAD_ALL_ACCESS, NULL, KernelMode,
+        &ScsiInfo->DeviceReplyThread, NULL);
+
+    if (!NT_SUCCESS(Status)) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto SoftTerminate;
     }
 
 Exit:
     WNBD_LOG_LOUD(": Exit");
     return Status;
+
+SoftTerminate:
+    if(request_thread_handle)
+        ZwClose(request_thread_handle);
+    if(reply_thread_handle)
+        ZwClose(reply_thread_handle);
+    ScsiInfo->SoftTerminateDevice = TRUE;
+    WnbdReleaseSemaphore(&ScsiInfo->DeviceEvent, 0, 1, FALSE);
+    Status = STATUS_INSUFFICIENT_RESOURCES;
+    goto Exit;
 }
 
 VOID
@@ -388,6 +435,51 @@ WnbdSetDeviceMissing(_In_ PVOID Handle,
     return TRUE;
 }
 
+
+VOID
+WnbdDrainQueueOnClose(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation)
+{
+    if (IsListEmpty(&DeviceInformation->RequestListHead))
+        goto Reply;
+    PLIST_ENTRY ItemLink, ItemNext;
+    KIRQL Irql = { 0 };
+    PSRB_QUEUE_ELEMENT Element = NULL;
+    KeAcquireSpinLock(&DeviceInformation->RequestListLock, &Irql);
+    LIST_FORALL_SAFE(&DeviceInformation->RequestListHead, ItemLink, ItemNext) {
+        Element = CONTAINING_RECORD(ItemLink, SRB_QUEUE_ELEMENT, Link);
+        if (Element) {
+            RemoveEntryList(&Element->Link);
+            Element->Srb->DataTransferLength = 0;
+            Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
+            StorPortNotification(RequestComplete, Element->DeviceExtension,
+                Element->Srb);
+            ExFreePool(Element);
+        }
+        Element = NULL;
+    }
+    KeReleaseSpinLock(&DeviceInformation->RequestListLock, Irql);
+Reply:
+    if (IsListEmpty(&DeviceInformation->ReplyListHead))
+        return;
+    KeAcquireSpinLock(&DeviceInformation->ReplyListLock, &Irql);
+    LIST_FORALL_SAFE(&DeviceInformation->ReplyListHead, ItemLink, ItemNext) {
+
+        Element = CONTAINING_RECORD(ItemLink, SRB_QUEUE_ELEMENT, Link);
+        if (Element) {
+            RemoveEntryList(&Element->Link);
+            if (!Element->Aborted) {
+                Element->Srb->DataTransferLength = 0;
+                Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
+                StorPortNotification(RequestComplete, Element->DeviceExtension,
+                    Element->Srb);
+            }
+            ExFreePool(Element);
+        }
+        Element = NULL;
+    }
+    KeReleaseSpinLock(&DeviceInformation->ReplyListLock, Irql);
+}
+
 _Use_decl_annotations_
 NTSTATUS
 WnbdDeleteConnection(PGLOBAL_INFORMATION GInfo,
@@ -413,16 +505,17 @@ WnbdDeleteConnection(PGLOBAL_INFORMATION GInfo,
         TargetIndex = ScsiInfo->TargetIndex;
         BusIndex = ScsiInfo->BusIndex;
         ScsiInfo->SoftTerminateDevice = TRUE;
-        KeSetEvent(&ScsiInfo->DeviceEvent, (KPRIORITY)0, FALSE);
+        WnbdReleaseSemaphore(&ScsiInfo->DeviceEvent, 0, 1, FALSE);
         LARGE_INTEGER Timeout;
-        Timeout.QuadPart = (-1 * 1000 * 10000);
-        KeWaitForSingleObject(ScsiInfo->DeviceThread, Executive, KernelMode, FALSE, &Timeout);
-        if (-1 != ScsiInfo->Socket) {
-            WNBD_LOG_INFO("Closing socket FD: %d", ScsiInfo->Socket);
-            Close(ScsiInfo->Socket);
-            ScsiInfo->Socket = -1;
-        }
-        ObDereferenceObject(ScsiInfo->DeviceThread);
+        // TODO: consider making this configurable, currently 120s.
+        Timeout.QuadPart = (-120 * 1000 * 10000);
+        CloseConnection(ScsiInfo);
+        KeWaitForSingleObject(ScsiInfo->DeviceRequestThread, Executive, KernelMode, FALSE, NULL);
+        KeWaitForSingleObject(ScsiInfo->DeviceReplyThread, Executive, KernelMode, FALSE, &Timeout);
+        ObDereferenceObject(ScsiInfo->DeviceRequestThread);
+        ObDereferenceObject(ScsiInfo->DeviceReplyThread);
+        WnbdDrainQueueOnClose(ScsiInfo);
+        DisconnectConnection(ScsiInfo);
 
         if(!WnbdSetDeviceMissing(ScsiInfo->Device,TRUE)) {
             WNBD_LOG_WARN("Could not delete media because it is still in use.");

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -210,6 +210,8 @@ WnbdInitializeScsiInfo(_In_ PSCSI_DEVICE_INFORMATION ScsiInfo)
     Status = ObReferenceObjectByHandle(reply_thread_handle, THREAD_ALL_ACCESS, NULL, KernelMode,
         &ScsiInfo->DeviceReplyThread, NULL);
 
+    RtlZeroMemory(&ScsiInfo->Stats, sizeof(WNBD_STATS));
+
     if (!NT_SUCCESS(Status)) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto SoftTerminate;
@@ -474,6 +476,7 @@ Reply:
                     Element->Srb);
             }
             ExFreePool(Element);
+            InterlockedDecrement64(&DeviceInformation->Stats.PendingSubmittedIORequests);
         }
         Element = NULL;
     }
@@ -725,6 +728,59 @@ WnbdParseUserIOCTL(PVOID GlobalHandle,
                 (REG_DWORD << RTL_QUERY_REGISTRY_TYPECHECK_SHIFT), &temp)) {
                 WnbdSetLogLevel(temp);
             }
+        }
+        break;
+
+        case IOCTL_WNBD_STATS:
+        {
+            // Retrieve per mapping stats. TODO: consider providing global stats.
+            WNBD_LOG_LOUD("IOCTL_WNBDVM_STATS");
+            PCONNECTION_INFO Info = (PCONNECTION_INFO) Irp->AssociatedIrp.SystemBuffer;
+
+            if(!Info || CHECK_I_LOCATION(IoLocation, CONNECTION_INFO)) {
+                WNBD_LOG_ERROR(": IOCTL = 0x%x. Bad input buffer",
+                    IoLocation->Parameters.DeviceIoControl.IoControlCode);
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            if(!wcslen((PWSTR) &Info->InstanceName)) {
+                WNBD_LOG_ERROR(": IOCTL = 0x%x. InstanceName Error",
+                    IoLocation->Parameters.DeviceIoControl.IoControlCode);
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            KeEnterCriticalRegion();
+            ExAcquireResourceExclusiveLite(&GInfo->ConnectionMutex, TRUE);
+            if(!Irp->AssociatedIrp.SystemBuffer || CHECK_O_LOCATION(IoLocation, WNBD_STATS)) {
+                WNBD_LOG_ERROR(": IOCTL = 0x%x. Bad output buffer",
+                    IoLocation->Parameters.DeviceIoControl.IoControlCode);
+
+                Irp->IoStatus.Information = sizeof(WNBD_STATS);
+                ExReleaseResourceLite(&GInfo->ConnectionMutex);
+                KeLeaveCriticalRegion();
+                break;
+            }
+
+            PUSER_ENTRY DiskEntry = NULL;
+            if(!WnbdFindConnection(GInfo, Info, &DiskEntry)) {
+                ExReleaseResourceLite(&GInfo->ConnectionMutex);
+                KeLeaveCriticalRegion();
+                Status = STATUS_OBJECT_NAME_NOT_FOUND;
+                WNBD_LOG_ERROR(": IOCTL = 0x%x. Connection does not exist",
+                    IoLocation->Parameters.DeviceIoControl.IoControlCode);
+                break;
+            }
+
+            PWNBD_STATS OutStatus = (PWNBD_STATS) Irp->AssociatedIrp.SystemBuffer;
+            RtlCopyMemory(OutStatus, &DiskEntry->ScsiInformation->Stats, sizeof(WNBD_STATS));
+
+            Irp->IoStatus.Information = sizeof(WNBD_STATS);
+            ExReleaseResourceLite(&GInfo->ConnectionMutex);
+            KeLeaveCriticalRegion();
+
+            Status = STATUS_SUCCESS;
         }
         break;
 

--- a/driver/userspace.h
+++ b/driver/userspace.h
@@ -62,6 +62,7 @@ typedef struct _SCSI_DEVICE_INFORMATION
     BOOLEAN                     HardTerminateDevice;
     BOOLEAN                     SoftTerminateDevice;
 
+    WNBD_STATS                  Stats;
     PVOID                       ReadPreallocatedBuffer;
     ULONG                       ReadPreallocatedBufferLength;
     PVOID                       WritePreallocatedBuffer;

--- a/driver/userspace_shared.h
+++ b/driver/userspace_shared.h
@@ -21,6 +21,7 @@ extern "C" {
 #define IOCTL_WNBD_UNMAP  CTL_CODE(FILE_DEVICE_WNBD, USER_WNBD_IOCTL_START+2, METHOD_BUFFERED, FILE_WRITE_ACCESS)
 #define IOCTL_WNBD_LIST   CTL_CODE(FILE_DEVICE_WNBD, USER_WNBD_IOCTL_START+3, METHOD_BUFFERED, FILE_WRITE_ACCESS)
 #define IOCTL_WNBD_DEBUG  CTL_CODE(FILE_DEVICE_WNBD, USER_WNBD_IOCTL_START+4, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+#define IOCTL_WNBD_STATS CTL_CODE(FILE_DEVICE_WNBD, USER_WNBD_IOCTL_START+5, METHOD_BUFFERED, FILE_WRITE_ACCESS)
 
 static const GUID WNBD_GUID = {
       0x949dd17c,
@@ -59,6 +60,17 @@ typedef struct _DISK_INFO_LIST {
     ULONG                   ActiveListCount;
     DISK_INFO          ActiveEntry[1];
 } DISK_INFO_LIST, *PDISK_INFO_LIST;
+
+typedef struct _WNBD_STATS {
+    INT64 TotalReceivedIORequests;
+    INT64 TotalSubmittedIORequests;
+    INT64 TotalReceivedIOReplies;
+    INT64 UnsubmittedIORequests;
+    INT64 PendingSubmittedIORequests;
+    INT64 AbortedSubmittedIORequests;
+    INT64 AbortedUnsubmittedIORequests;
+    INT64 CompletedAbortedIORequests;
+} WNBD_STATS, *PWNBD_STATS;
 
 #ifdef __cplusplus
 }

--- a/driver/util.c
+++ b/driver/util.c
@@ -9,7 +9,9 @@
 #include "debug.h"
 #include "rbd_protocol.h"
 #include "scsi_driver_extensions.h"
+#include "scsi_function.h"
 #include "scsi_trace.h"
+#include "srb_helper.h"
 #include "userspace.h"
 #include "util.h"
 
@@ -25,7 +27,16 @@ WnbdDeleteScsiInformation(_In_ PVOID ScsiInformation)
     PLIST_ENTRY Request;
     PSRB_QUEUE_ELEMENT Element;
 
-    while ((Request = ExInterlockedRemoveHeadList(&ScsiInfo->ListHead, &ScsiInfo->ListLock)) != NULL) {
+    while ((Request = ExInterlockedRemoveHeadList(&ScsiInfo->RequestListHead, &ScsiInfo->RequestListLock)) != NULL) {
+        Element = CONTAINING_RECORD(Request, SRB_QUEUE_ELEMENT, Link);
+        Element->Srb->DataTransferLength = 0;
+        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
+        PWNBD_SCSI_DEVICE Device = (PWNBD_SCSI_DEVICE)ScsiInfo->Device;
+        InterlockedDecrement(&Device->OutstandingIoCount);
+        ExFreePool(Element);
+    }
+
+    while ((Request = ExInterlockedRemoveHeadList(&ScsiInfo->ReplyListHead, &ScsiInfo->ReplyListLock)) != NULL) {
         Element = CONTAINING_RECORD(Request, SRB_QUEUE_ELEMENT, Link);
         Element->Srb->DataTransferLength = 0;
         Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
@@ -42,9 +53,21 @@ WnbdDeleteScsiInformation(_In_ PVOID ScsiInformation)
         ScsiInfo->InquiryData = NULL;
     }
 
+    ExDeleteResourceLite(&ScsiInfo->SocketLock);
+
     if(ScsiInfo->UserEntry) {
         ExFreePool(ScsiInfo->UserEntry);
         ScsiInfo->UserEntry = NULL;
+    }
+
+    if (ScsiInfo->ReadPreallocatedBuffer) {
+        ExFreePool(ScsiInfo->ReadPreallocatedBuffer);
+        ScsiInfo->ReadPreallocatedBuffer = NULL;
+    }
+
+    if (ScsiInfo->WritePreallocatedBuffer) {
+        ExFreePool(ScsiInfo->WritePreallocatedBuffer);
+        ScsiInfo->WritePreallocatedBuffer = NULL;
     }
 
     if (-1 != ScsiInfo->Socket) {
@@ -72,7 +95,7 @@ WnbdDeleteDevices(_In_ PWNBD_EXTENSION Ext,
     PLIST_ENTRY Link, Next;
     KeEnterCriticalRegion();
     ExAcquireResourceSharedLite(&Ext->DeviceResourceLock, TRUE);
-
+    ExAcquireResourceExclusiveLite(&((PGLOBAL_INFORMATION)Ext->GlobalInformation)->ConnectionMutex, TRUE);
     LIST_FORALL_SAFE(&Ext->DeviceList, Link, Next) {
         Device = (PWNBD_SCSI_DEVICE)CONTAINING_RECORD(Link, WNBD_SCSI_DEVICE, ListEntry);
         if (Device->ReportedMissing || All) {
@@ -90,7 +113,7 @@ WnbdDeleteDevices(_In_ PWNBD_EXTENSION Ext,
             }
         }
     }
-
+    ExReleaseResourceLite(&((PGLOBAL_INFORMATION)Ext->GlobalInformation)->ConnectionMutex);
     ExReleaseResourceLite(&Ext->DeviceResourceLock);
     KeLeaveCriticalRegion();
 
@@ -186,21 +209,13 @@ WnbdProcessDeviceThreadRequestsReads(_In_ PSCSI_DEVICE_INFORMATION DeviceInforma
     WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceInformation);
     ASSERT(Element);
-    ULONG StorResult;
-    PVOID Buffer;
     NTSTATUS Status = STATUS_SUCCESS;
 
-    StorResult = StorPortGetSystemAddress(Element->DeviceExtension, Element->Srb, &Buffer);
-    if (STOR_STATUS_SUCCESS != StorResult) {
-        Status = SRB_STATUS_INTERNAL_ERROR;
-    } else {
-        NbdReadStat(DeviceInformation->Socket,
-                    Element->StartingLbn,
-                    Element->ReadLength,
-                    &Status,
-                    Buffer);
-    }
-    Element->Srb->DataTransferLength = Element->ReadLength;
+    NbdReadStat(DeviceInformation->Socket,
+                Element->StartingLbn,
+                Element->ReadLength,
+                &Status,
+                Element->Tag);
 
     WNBD_LOG_LOUD(": Exit");
     return Status;
@@ -225,12 +240,50 @@ WnbdProcessDeviceThreadRequestsWrites(_In_ PSCSI_DEVICE_INFORMATION DeviceInform
                      Element->StartingLbn,
                      Element->ReadLength,
                      &Status,
-                     Buffer);
+                     Buffer,
+                     &DeviceInformation->WritePreallocatedBuffer,
+                     &DeviceInformation->WritePreallocatedBufferLength,
+                     Element->Tag);
     }
-    Element->Srb->DataTransferLength = Element->ReadLength;
 
     WNBD_LOG_LOUD(": Exit");
     return Status;
+}
+
+VOID DisconnectConnection(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation) {
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(
+        &DeviceInformation->SocketLock, TRUE);
+    if (-1 != DeviceInformation->SocketToClose) {
+        WNBD_LOG_INFO("Closing socket FD: %d", DeviceInformation->Socket);
+        if (-1 != DeviceInformation->Socket) {
+            Close(DeviceInformation->Socket);
+        } else {
+            Close(DeviceInformation->SocketToClose);
+        }
+        DeviceInformation->Socket = -1;
+        DeviceInformation->SocketToClose = -1;
+        DeviceInformation->Device->Missing = TRUE;
+    }
+    ExReleaseResourceLite(&DeviceInformation->SocketLock);
+    KeLeaveCriticalRegion();
+}
+
+VOID CloseConnection(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation) {
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(
+        &DeviceInformation->SocketLock, TRUE);
+    if (-1 != DeviceInformation->Socket) {
+        WNBD_LOG_INFO("Closing socket FD: %d", DeviceInformation->Socket);
+        DeviceInformation->SocketToClose = DeviceInformation->Socket;
+        Disconnect(DeviceInformation->Socket);
+        DeviceInformation->Socket = -1;
+        if (DeviceInformation->Device) {
+            DeviceInformation->Device->Missing = TRUE;
+        }
+    }
+    ExReleaseResourceLite(&DeviceInformation->SocketLock);
+    KeLeaveCriticalRegion();
 }
 
 VOID
@@ -242,17 +295,33 @@ WnbdProcessDeviceThreadRequests(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation)
     PLIST_ENTRY Request;
     PSRB_QUEUE_ELEMENT Element;
     NTSTATUS Status = STATUS_SUCCESS;
+    static UINT64 RequestTag = 0;
 
-    while ((Request = ExInterlockedRemoveHeadList(&DeviceInformation->ListHead, &DeviceInformation->ListLock)) != NULL) {
+    while ((Request = ExInterlockedRemoveHeadList(
+            &DeviceInformation->RequestListHead,
+            &DeviceInformation->RequestListLock)) != NULL) {
+        RequestTag += 1;
         Element = CONTAINING_RECORD(Request, SRB_QUEUE_ELEMENT, Link);
+        Element->Tag = RequestTag;
         Element->Srb->DataTransferLength = 0;
         PCDB Cdb = (PCDB)&Element->Srb->Cdb;
-        PWNBD_SCSI_DEVICE Device = (PWNBD_SCSI_DEVICE)DeviceInformation->Device;
+        WNBD_LOG_INFO("Processing request. Address: %p Tag: 0x%llx",
+                      Status, Element->Srb, Element->Tag);
+
         switch (Cdb->AsByte[0]) {
         case SCSIOP_READ6:
         case SCSIOP_READ:
         case SCSIOP_READ12:
         case SCSIOP_READ16:
+            KeWaitForSingleObject(&DeviceInformation->RequestSemaphore, Executive, KernelMode, FALSE, NULL);
+            if(DeviceInformation->SoftTerminateDevice || DeviceInformation->HardTerminateDevice) {
+                return;
+            }
+            ExInterlockedInsertTailList(
+                &DeviceInformation->ReplyListHead,
+                &Element->Link, &DeviceInformation->ReplyListLock);
+            WNBD_LOG_LOUD("Pending request. Address: %p Tag: 0x%llx",
+                          Element->Srb, Element->Tag);
             Status = WnbdProcessDeviceThreadRequestsReads(DeviceInformation, Element);
             break;
 
@@ -260,57 +329,49 @@ WnbdProcessDeviceThreadRequests(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation)
         case SCSIOP_WRITE:
         case SCSIOP_WRITE12:
         case SCSIOP_WRITE16:
+            KeWaitForSingleObject(&DeviceInformation->RequestSemaphore, Executive, KernelMode, FALSE, NULL);
+            if(DeviceInformation->SoftTerminateDevice || DeviceInformation->HardTerminateDevice) {
+                return;
+            }
+            ExInterlockedInsertTailList(
+                &DeviceInformation->ReplyListHead,
+                &Element->Link, &DeviceInformation->ReplyListLock);
+            WNBD_LOG_LOUD("Pending request. Address: %p Tag: 0x%llx",
+                          Element->Srb, Element->Tag);
             Status = WnbdProcessDeviceThreadRequestsWrites(DeviceInformation, Element);
             break;
 
         case SCSIOP_SYNCHRONIZE_CACHE:
         case SCSIOP_SYNCHRONIZE_CACHE16:
             /*
-             * We just want to mark synchronize as been successful
+             * TODO: consider sending an actual NBD flush.
              */
-            Status = STATUS_SUCCESS;
-            break;
-
+            Element->Srb->DataTransferLength = 0;
+            Element->Srb->SrbStatus = SRB_STATUS_SUCCESS;
+            StorPortNotification(RequestComplete, Element->DeviceExtension, Element->Srb);
+            ExFreePool(Element);
+            return;
         default:
             Status = STATUS_DRIVER_INTERNAL_ERROR;
             break;
         }
 
-        if (STATUS_SUCCESS == Status) {
-            Element->Srb->SrbStatus = SRB_STATUS_SUCCESS;
-        } else {
-            Element->Srb->DataTransferLength = 0;
-            Element->Srb->SrbStatus = SRB_STATUS_TIMEOUT;
-            WNBD_LOG_INFO("FD failed with: %x", Status);
+        if (Status) {
+            WNBD_LOG_INFO("FD failed with: %x. Address: %p Tag: 0x%llx",
+                          Status, Element->Srb, Element->Tag);
             if (STATUS_CONNECTION_RESET == Status ||
                 STATUS_CONNECTION_DISCONNECTED == Status ||
                 STATUS_CONNECTION_ABORTED == Status) {
-                Element->Srb->SrbStatus = SRB_STATUS_ERROR;
-                KeEnterCriticalRegion();
-                ExAcquireResourceExclusiveLite(&DeviceInformation->GlobalInformation->ConnectionMutex, TRUE);
-                if (-1 != DeviceInformation->Socket) {
-                    WNBD_LOG_INFO("Closing socket FD: %d", DeviceInformation->Socket);
-                    Close(DeviceInformation->Socket);
-                    DeviceInformation->Socket = -1;
-                    Device->Missing = TRUE;
-                }
-                ExReleaseResourceLite(&DeviceInformation->GlobalInformation->ConnectionMutex);
-                KeLeaveCriticalRegion();
+                CloseConnection(DeviceInformation);
             }
         }
-
-        InterlockedDecrement(&Device->OutstandingIoCount);
-        WNBD_LOG_INFO("Notifying StorPort of completion of %p status: 0x%x(%s)",
-            Element->Srb, Element->Srb->SrbStatus, WnbdToStringSrbStatus(Element->Srb->SrbStatus));
-        StorPortNotification(RequestComplete, Element->DeviceExtension, Element->Srb);
-        ExFreePool(Element);
     }
 
     WNBD_LOG_LOUD(": Exit");
 }
 
 VOID
-WnbdDeviceThread(_In_ PVOID Context)
+WnbdDeviceRequestThread(_In_ PVOID Context)
 {
     WNBD_LOG_LOUD(": Enter");
 
@@ -337,5 +398,169 @@ WnbdDeviceThread(_In_ PVOID Context)
             WNBD_LOG_INFO("Soft terminate thread: %p", DeviceInformation);
             PsTerminateSystemThread(STATUS_SUCCESS);
         }
+    }
+}
+
+VOID
+WnbdDeviceReplyThread(_In_ PVOID Context)
+{
+    WNBD_LOG_LOUD(": Enter");
+    ASSERT(Context);
+
+    PSCSI_DEVICE_INFORMATION DeviceInformation;
+    PAGED_CODE();
+
+    DeviceInformation = (PSCSI_DEVICE_INFORMATION) Context;
+
+    KeSetPriorityThread(KeGetCurrentThread(), LOW_REALTIME_PRIORITY);
+
+    while (TRUE) {
+
+        if (DeviceInformation->SoftTerminateDevice) {
+            WNBD_LOG_INFO("Soft terminate thread: %p", DeviceInformation);
+            PsTerminateSystemThread(STATUS_SUCCESS);
+        }
+
+        WnbdProcessDeviceThreadReplies(DeviceInformation);
+    }
+}
+
+_Use_decl_annotations_
+inline BOOLEAN
+IsReadSrb(PSCSI_REQUEST_BLOCK Srb)
+{
+    PCDB Cdb = SrbGetCdb(Srb);
+    if(!Cdb) {
+        return FALSE;
+    }
+
+    switch (Cdb->AsByte[0]) {
+    case SCSIOP_READ6:
+    case SCSIOP_READ:
+    case SCSIOP_READ12:
+    case SCSIOP_READ16:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+VOID
+WnbdProcessDeviceThreadReplies(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation)
+{
+    WNBD_LOG_LOUD(": Enter");
+    ASSERT(DeviceInformation);
+
+    PSRB_QUEUE_ELEMENT Element = NULL;
+    NTSTATUS Status = STATUS_SUCCESS;
+    NBD_REPLY Reply = { 0 };
+    PVOID SrbBuff = NULL, TempBuff = NULL;
+    NTSTATUS error = STATUS_SUCCESS;
+
+    Status = NbdReadReply(DeviceInformation->Socket, &Reply);
+    if (Status) {
+        CloseConnection(DeviceInformation);
+        // Sleep for a bit to avoid a lazy poll here since the connection
+        // could already be closed by the time the device is actually removed.
+        LARGE_INTEGER Timeout;
+        Timeout.QuadPart = (-1 * 100 * 10000);
+        KeDelayExecutionThread(KernelMode, FALSE, &Timeout);
+        return;
+    }
+    PLIST_ENTRY ItemLink, ItemNext;
+    KIRQL Irql = { 0 };
+    KeAcquireSpinLock(&DeviceInformation->ReplyListLock, &Irql);
+    LIST_FORALL_SAFE(&DeviceInformation->ReplyListHead, ItemLink, ItemNext) {
+        Element = CONTAINING_RECORD(ItemLink, SRB_QUEUE_ELEMENT, Link);
+        if (Element->Tag == Reply.Handle) {
+            /* Remove the element from the list once found*/
+            RemoveEntryList(&Element->Link);
+            break;
+        }
+        Element = NULL;
+    }
+    KeReleaseSpinLock(&DeviceInformation->ReplyListLock, Irql);
+    if(!Element) {
+        WNBD_LOG_ERROR("Received reply with no matching request tag: 0x%llx",
+            Reply.Handle);
+        CloseConnection(DeviceInformation);
+        goto Exit;
+    }
+    WNBD_LOG_LOUD("Received reply header for %p 0x%llx.", Element->Srb, Element->Tag);
+
+    ULONG StorResult;
+    if(!Element->Aborted) {
+        StorResult = StorPortGetSystemAddress(Element->DeviceExtension, Element->Srb, &SrbBuff);
+        if (STOR_STATUS_SUCCESS != StorResult) {
+            WNBD_LOG_ERROR("Could not get SRB %p 0x%llx data buffer. Error: %d.",
+                           Element->Srb, Element->Tag, error);
+            Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
+            CloseConnection(DeviceInformation);
+            goto Exit;
+        }
+    }
+
+    if(!Reply.Error && IsReadSrb(Element->Srb)) {
+        if (Element->ReadLength > DeviceInformation->ReadPreallocatedBufferLength) {
+            TempBuff = NbdMalloc(Element->ReadLength);
+            if (!TempBuff) {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                CloseConnection(DeviceInformation);
+                goto Exit;
+            }
+            DeviceInformation->ReadPreallocatedBufferLength = Element->ReadLength;
+            ExFreePool(DeviceInformation->ReadPreallocatedBuffer);
+            DeviceInformation->ReadPreallocatedBuffer = TempBuff;
+        } else {
+            TempBuff = DeviceInformation->ReadPreallocatedBuffer;
+        }
+
+        if (-1 == RbdReadExact(DeviceInformation->Socket, TempBuff, Element->ReadLength, &error)) {
+            WNBD_LOG_ERROR("Failed receiving reply %p 0x%llx. Error: %d",
+                           Element->Srb, Element->Tag, error);
+            Element->Srb->DataTransferLength = 0;
+            Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
+            CloseConnection(DeviceInformation);
+            goto Exit;
+        } else {
+            if(!Element->Aborted) {
+                RtlCopyMemory(SrbBuff, TempBuff, Element->ReadLength);
+            }
+        }
+    }
+    if (Reply.Error) {
+        // TODO: do we care about the actual error?
+        WNBD_LOG_INFO("NBD reply contains error: %llu", Reply.Error);
+        Element->Srb->DataTransferLength = 0;
+        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
+    }
+    else {
+        // TODO: rename ReadLength to DataLength
+        Element->Srb->DataTransferLength = Element->ReadLength;
+        Element->Srb->SrbStatus = SRB_STATUS_SUCCESS;
+    }
+
+    if(Element->Aborted) {
+        WNBD_LOG_WARN("Got reply for aborted request: %p 0x%llx.",
+                      Element->Srb, Element->Tag);
+    }
+    else {
+        WNBD_LOG_LOUD("Successfully completed request %p 0x%llx.",
+                      Element->Srb, Element->Tag);
+
+        WnbdReleaseSemaphore(&DeviceInformation->RequestSemaphore, 0, 1, FALSE);
+    }
+
+Exit:
+    InterlockedDecrement(&DeviceInformation->Device->OutstandingIoCount);
+    if (Element) {
+        if(!Element->Aborted) {
+            WNBD_LOG_INFO("Notifying StorPort of completion of %p status: 0x%x(%s)",
+                Element->Srb, Element->Srb->SrbStatus,
+                WnbdToStringSrbStatus(Element->Srb->SrbStatus));
+            StorPortNotification(RequestComplete, Element->DeviceExtension,
+                                 Element->Srb);
+        }
+        ExFreePool(Element);
     }
 }

--- a/driver/util.h
+++ b/driver/util.h
@@ -8,6 +8,7 @@
 #define UTIL_H 1
 
 #include "common.h"
+#include "userspace.h"
 
 static const int MultiplyDeBruijnBitPosition2[32] =
 {
@@ -32,10 +33,22 @@ typedef struct _SRB_QUEUE_ELEMENT {
     UINT64 StartingLbn;
     ULONG ReadLength;
     PVOID DeviceExtension;
+    UINT64 Tag;
+    BOOLEAN Aborted;
 } SRB_QUEUE_ELEMENT, * PSRB_QUEUE_ELEMENT;
 
 VOID
-WnbdDeviceThread(_In_ PVOID Context);
+WnbdDeviceRequestThread(_In_ PVOID Context);
+#pragma alloc_text (PAGE, WnbdDeviceRequestThread)
+VOID
+WnbdDeviceReplyThread(_In_ PVOID Context);
+#pragma alloc_text (PAGE, WnbdDeviceReplyThread)
+BOOLEAN
+IsReadSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
+VOID
+WnbdProcessDeviceThreadReplies(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation);
+VOID CloseConnection(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation);
+VOID DisconnectConnection(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation);
 
 #define LIST_FORALL_SAFE(_headPtr, _itemPtr, _nextPtr)                \
     for (_itemPtr = (_headPtr)->Flink, _nextPtr = (_itemPtr)->Flink;  \

--- a/lib/ksocket_wsk/berkeley.c
+++ b/lib/ksocket_wsk/berkeley.c
@@ -616,7 +616,6 @@ int Send(int sockfd, const void* buf, size_t len, int flags, PNTSTATUS error)
 {
   NTSTATUS Status;
   PKSOCKET Socket = KsArray[FROM_SOCKETFD(sockfd)];
-  flags |= WSK_FLAG_NODELAY;
 
   ULONG Length = (ULONG)len;
   Status = KsSend(Socket, (PVOID)buf, &Length, flags);
@@ -670,6 +669,18 @@ int RecvFrom(int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_
   return NT_SUCCESS(Status)
     ? (int)Length
     : -1;
+}
+
+int Disconnect(int sockfd)
+{
+  NTSTATUS Status;
+  PKSOCKET Socket = KsArray[FROM_SOCKETFD(sockfd)];
+
+  Status = KsDisconnectSocket(Socket);
+
+  return NT_SUCCESS(Status)
+      ? 0
+      : -1;
 }
 
 int Close(int sockfd)

--- a/lib/ksocket_wsk/berkeley.h
+++ b/lib/ksocket_wsk/berkeley.h
@@ -32,6 +32,7 @@ int SendTo(int sockfd, const void *buf, size_t len, int flags, const struct sock
 int Recv(int sockfd, void* buf, size_t len, int flags, PNTSTATUS error);
 int RecvFrom(int sockfd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen);
 int Close(int sockfd);
+int Disconnect(int sockfd);
 
 #ifdef __cplusplus
 }

--- a/lib/ksocket_wsk/ksocket.c
+++ b/lib/ksocket_wsk/ksocket.c
@@ -490,7 +490,6 @@ KsDisconnectSocket(
 
   if (!NT_SUCCESS(Status))
   {
-    KspAsyncContextFree(&AsyncContext);
     return Status;
   }
 
@@ -522,8 +521,7 @@ KsCloseSocket(
 
   if (!NT_SUCCESS(Status))
   {
-    KspAsyncContextFree(&AsyncContext);
-    return Status;
+    goto Exit;
   }
 
   //
@@ -537,10 +535,11 @@ KsCloseSocket(
   //
   // Free the async context.
   //
+  KspAsyncContextFree(&AsyncContext);
 
+Exit:
   KspAsyncContextFree(&Socket->AsyncContextRead);
   KspAsyncContextFree(&Socket->AsyncContextWrite);
-  KspAsyncContextFree(&AsyncContext);
 
   //
   // Free memory for the socket structure.

--- a/lib/ksocket_wsk/ksocket.c
+++ b/lib/ksocket_wsk/ksocket.c
@@ -31,8 +31,9 @@ typedef struct _KSOCKET
     PWSK_PROVIDER_STREAM_DISPATCH WskStreamDispatch;
 #endif
   };
-
-  KSOCKET_ASYNC_CONTEXT AsyncContext;
+  LONG operation;
+  KSOCKET_ASYNC_CONTEXT AsyncContextRead;
+  KSOCKET_ASYNC_CONTEXT AsyncContextWrite;
 } KSOCKET, *PKSOCKET;
 
 //////////////////////////////////////////////////////////////////////////
@@ -225,10 +226,8 @@ KspAsyncContextWaitForCompletion(
   _Inout_ PNTSTATUS Status
   )
 {
-  /* Timeout default value of 120 seconds */
-  // TODO make the timeout configurable
-  LARGE_INTEGER	Timeout;
-  Timeout.QuadPart = (-120 * 1000 * 10000);
+  // TODO: accept a timeout value and make it configurable,
+  // where applicable.
   if (*Status == STATUS_PENDING)
   {
     KeWaitForSingleObject(
@@ -236,8 +235,8 @@ KspAsyncContextWaitForCompletion(
       Executive,
       KernelMode,
       FALSE,
-      &Timeout
-      );
+      NULL
+    );
 
     *Status = AsyncContext->Irp->IoStatus.Status;
   }
@@ -392,7 +391,14 @@ KsCreateSocket(
   //
   // Allocate async context for the socket.
   //
-  Status = KspAsyncContextAllocate(&NewSocket->AsyncContext);
+  Status = KspAsyncContextAllocate(&NewSocket->AsyncContextRead);
+
+  if (!NT_SUCCESS(Status))
+  {
+    return Status;
+  }
+
+  Status = KspAsyncContextAllocate(&NewSocket->AsyncContextWrite);
 
   if (!NT_SUCCESS(Status))
   {
@@ -414,10 +420,10 @@ KsCreateSocket(
     NULL,                       // OwningProcess
     NULL,                       // OwningThread
     NULL,                       // SecurityDescriptor
-    NewSocket->AsyncContext.Irp // Irp
+    NewSocket->AsyncContextRead.Irp // Irp
     );
 
-  KspAsyncContextWaitForCompletion(&NewSocket->AsyncContext, &Status);
+  KspAsyncContextWaitForCompletion(&NewSocket->AsyncContextRead, &Status);
 
   //
   // Save the socket instance and the socket dispatch table.
@@ -425,9 +431,9 @@ KsCreateSocket(
 
   if (NT_SUCCESS(Status))
   {
-    NewSocket->WskSocket = (PWSK_SOCKET)NewSocket->AsyncContext.Irp->IoStatus.Information;
+    NewSocket->WskSocket = (PWSK_SOCKET)NewSocket->AsyncContextRead.Irp->IoStatus.Information;
     NewSocket->WskDispatch = (PVOID)NewSocket->WskSocket->Dispatch;
-
+    NewSocket->operation = 0;
     *Socket = NewSocket;
   }
 
@@ -470,6 +476,39 @@ KsCreateDatagramSocket(
   return KsCreateSocket(Socket, AddressFamily, SocketType, Protocol, WSK_FLAG_DATAGRAM_SOCKET);
 }
 
+
+NTSTATUS
+NTAPI
+KsDisconnectSocket(
+    _In_ PKSOCKET Socket
+)
+{
+  NTSTATUS Status = STATUS_UNSUCCESSFUL;
+
+  KSOCKET_ASYNC_CONTEXT AsyncContext;
+  Status = KspAsyncContextAllocate(&AsyncContext);
+
+  if (!NT_SUCCESS(Status))
+  {
+    KspAsyncContextFree(&AsyncContext);
+    return Status;
+  }
+
+  //
+  // Close the WSK socket.
+  //
+  Status = Socket->WskConnectionDispatch->WskDisconnect(
+    Socket->WskSocket,
+    NULL,
+    0,
+    AsyncContext.Irp
+  );
+  KspAsyncContextWaitForCompletion(&AsyncContext, &Status);
+  KspAsyncContextFree(&AsyncContext);
+
+  return Status;
+}
+
 NTSTATUS
 NTAPI
 KsCloseSocket(
@@ -478,28 +517,30 @@ KsCloseSocket(
 {
   NTSTATUS Status = STATUS_UNSUCCESSFUL;
 
-  PIRP Irp = ExAllocatePoolWithTag(NonPagedPoolNx, IoSizeOfIrp(1), MEMORY_TAG);;
-  if (!Irp) {
-    return STATUS_INSUFFICIENT_RESOURCES;
+  KSOCKET_ASYNC_CONTEXT AsyncContext;
+  Status = KspAsyncContextAllocate(&AsyncContext);
+
+  if (!NT_SUCCESS(Status))
+  {
+    KspAsyncContextFree(&AsyncContext);
+    return Status;
   }
-  IoInitializeIrp(Irp, IoSizeOfIrp(1), 1);
-  IoSetCompletionRoutine(Irp, KspNoWaitCompletionRoutine, NULL, TRUE, TRUE, TRUE);
 
   //
   // Close the WSK socket.
   //
-
-
   Status = Socket->WskConnectionDispatch->WskCloseSocket(
     Socket->WskSocket,
-    Irp
-    );
-
+    AsyncContext.Irp
+  );
+  KspAsyncContextWaitForCompletion(&AsyncContext, &Status);
   //
   // Free the async context.
   //
 
-  KspAsyncContextFree(&Socket->AsyncContext);
+  KspAsyncContextFree(&Socket->AsyncContextRead);
+  KspAsyncContextFree(&Socket->AsyncContextWrite);
+  KspAsyncContextFree(&AsyncContext);
 
   //
   // Free memory for the socket structure.
@@ -523,7 +564,7 @@ KsBind(
   // Reset the async context.
   //
 
-  KspAsyncContextReset(&Socket->AsyncContext);
+  KspAsyncContextReset(&Socket->AsyncContextRead);
 
   //
   // Bind the socket.
@@ -533,10 +574,10 @@ KsBind(
     Socket->WskSocket,          // Socket
     LocalAddress,               // LocalAddress
     0,                          // Flags (reserved)
-    Socket->AsyncContext.Irp    // Irp
+    Socket->AsyncContextRead.Irp    // Irp
     );
 
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
+  KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
 
   return Status;
 }
@@ -556,7 +597,7 @@ KsAccept(
   // Reset the async context.
   //
 
-  KspAsyncContextReset(&Socket->AsyncContext);
+  KspAsyncContextReset(&Socket->AsyncContextRead);
 
   //
   // Accept the connection.
@@ -569,10 +610,10 @@ KsAccept(
     NULL,                       // AcceptSocketDispatch
     LocalAddress,               // LocalAddress
     RemoteAddress,              // RemoteAddress
-    Socket->AsyncContext.Irp    // Irp
+    Socket->AsyncContextRead.Irp    // Irp
     );
 
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
+  KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
 
   //
   // Save the socket instance and the socket dispatch table.
@@ -587,16 +628,23 @@ KsAccept(
       return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    KNewSocket->WskSocket = (PWSK_SOCKET)Socket->AsyncContext.Irp->IoStatus.Information;
+    KNewSocket->WskSocket = (PWSK_SOCKET)Socket->AsyncContextRead.Irp->IoStatus.Information;
     KNewSocket->WskDispatch = (PVOID)KNewSocket->WskSocket->Dispatch;
-    KspAsyncContextAllocate(&KNewSocket->AsyncContext);
 
-    Status = KspAsyncContextAllocate(&KNewSocket->AsyncContext);
+    Status = KspAsyncContextAllocate(&KNewSocket->AsyncContextRead);
 
     if (!NT_SUCCESS(Status))
     {
         ExFreePoolWithTag(KNewSocket, MEMORY_TAG);
         return Status;
+    }
+
+    Status = KspAsyncContextAllocate(&KNewSocket->AsyncContextWrite);
+
+    if (!NT_SUCCESS(Status))
+    {
+      ExFreePoolWithTag(KNewSocket, MEMORY_TAG);
+      return Status;
     }
 
     *NewSocket = KNewSocket;
@@ -618,7 +666,7 @@ KsConnect(
   // Reset the async context.
   //
 
-  KspAsyncContextReset(&Socket->AsyncContext);
+  KspAsyncContextReset(&Socket->AsyncContextRead);
 
   //
   // Bind the socket to the local address.
@@ -633,10 +681,10 @@ KsConnect(
     Socket->WskSocket,          // Socket
     (PSOCKADDR)&LocalAddress,   // LocalAddress
     0,                          // Flags (reserved)
-    Socket->AsyncContext.Irp    // Irp
+    Socket->AsyncContextRead.Irp    // Irp
     );
 
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
+  KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
 
   if (!NT_SUCCESS(Status))
   {
@@ -647,7 +695,7 @@ KsConnect(
   // Reset the async context (again).
   //
 
-  KspAsyncContextReset(&Socket->AsyncContext);
+  KspAsyncContextReset(&Socket->AsyncContextRead);
 
   //
   // Connect to the remote host.
@@ -660,10 +708,10 @@ KsConnect(
     Socket->WskSocket,          // Socket
     RemoteAddress,              // RemoteAddress
     0,                          // Flags (reserved)
-    Socket->AsyncContext.Irp    // Irp
+    Socket->AsyncContextRead.Irp    // Irp
     );
 
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
+  KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
 
   return Status;
 }
@@ -705,43 +753,45 @@ KsSendRecv(
   }
 
   //
-  // Reset the async context.
-  //
-
-  KspAsyncContextReset(&Socket->AsyncContext);
-
-  //
   // Send / receive the data.
   //
-
+  InterlockedIncrement(&Socket->operation);
   if (Send)
   {
+    KspAsyncContextReset(&Socket->AsyncContextWrite);
     Status = Socket->WskConnectionDispatch->WskSend(
       Socket->WskSocket,        // Socket
       &WskBuffer,               // Buffer
       Flags,                    // Flags
-      Socket->AsyncContext.Irp  // Irp
+      Socket->AsyncContextWrite.Irp  // Irp
       );
+    KspAsyncContextWaitForCompletion(&Socket->AsyncContextWrite, &Status);
   }
   else
   {
+    KspAsyncContextReset(&Socket->AsyncContextRead);
     Status = Socket->WskConnectionDispatch->WskReceive(
       Socket->WskSocket,        // Socket
       &WskBuffer,               // Buffer
       Flags,                    // Flags
-      Socket->AsyncContext.Irp  // Irp
+      Socket->AsyncContextRead.Irp  // Irp
       );
+    KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
   }
 
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
-
+  InterlockedDecrement(&Socket->operation);
   //
   // Set the number of bytes sent / received.
   //
 
   if (NT_SUCCESS(Status))
   {
-    *Length = (ULONG)Socket->AsyncContext.Irp->IoStatus.Information;
+    if (Send) {
+      *Length = (ULONG)Socket->AsyncContextWrite.Irp->IoStatus.Information;
+    }
+    else {
+      *Length = (ULONG)Socket->AsyncContextRead.Irp->IoStatus.Information;
+    }
   }
 
   //
@@ -794,17 +844,12 @@ KsSendRecvUdp(
   }
 
   //
-  // Reset the async context.
-  //
-
-  KspAsyncContextReset(&Socket->AsyncContext);
-
-  //
   // Send / receive the data.
   //
 
   if (Send)
   {
+    KspAsyncContextReset(&Socket->AsyncContextWrite);
     Status = Socket->WskDatagramDispatch->WskSendTo(
       Socket->WskSocket,        // Socket
       &WskBuffer,               // Buffer
@@ -812,8 +857,9 @@ KsSendRecvUdp(
       RemoteAddress,            // RemoteAddress
       0,                        // ControlInfoLength
       NULL,                     // ControlInfo
-      Socket->AsyncContext.Irp  // Irp
+      Socket->AsyncContextWrite.Irp  // Irp
       );
+    KspAsyncContextWaitForCompletion(&Socket->AsyncContextWrite, &Status);
   }
   else
   {
@@ -828,7 +874,7 @@ KsSendRecvUdp(
     //   ... This pointer is optional and can be NULL.  If the ControlInfoLength
     //   parameter is NULL, the ControlInfo parameter should be NULL.
     //
-
+    KspAsyncContextReset(&Socket->AsyncContextRead);
 #pragma prefast (                                                                           \
     suppress:__WARNING_INVALID_PARAM_VALUE_1,                                               \
     "If the ControlInfoLength parameter is NULL, the ControlInfo parameter should be NULL." \
@@ -843,12 +889,11 @@ KsSendRecvUdp(
       NULL,                     // ControlInfoLength
       NULL,                     // ControlInfo
       NULL,                     // ControlFlags
-      Socket->AsyncContext.Irp  // Irp
+      Socket->AsyncContextRead.Irp  // Irp
       );
+    KspAsyncContextWaitForCompletion(&Socket->AsyncContextRead, &Status);
 #pragma warning(default:6387)
   }
-
-  KspAsyncContextWaitForCompletion(&Socket->AsyncContext, &Status);
 
   //
   // Set the number of bytes sent / received.
@@ -856,7 +901,14 @@ KsSendRecvUdp(
 
   if (NT_SUCCESS(Status))
   {
-    *Length = (ULONG)Socket->AsyncContext.Irp->IoStatus.Information;
+      if (Send)
+      {
+        *Length = (ULONG)Socket->AsyncContextWrite.Irp->IoStatus.Information;
+      }
+      else
+      {
+        *Length = (ULONG)Socket->AsyncContextRead.Irp->IoStatus.Information;
+      }
   }
 
   //

--- a/lib/ksocket_wsk/ksocket.h
+++ b/lib/ksocket_wsk/ksocket.h
@@ -74,6 +74,12 @@ KsCreateDatagramSocket(
 
 NTSTATUS
 NTAPI
+KsDisconnectSocket(
+	_In_ PKSOCKET Socket
+);
+
+NTSTATUS
+NTAPI
 KsCloseSocket(
   _In_ PKSOCKET Socket
   );

--- a/userspace/userspace/ioctl.h
+++ b/userspace/userspace/ioctl.h
@@ -31,6 +31,9 @@ DWORD
 WnbdUnmap(PCHAR instanceName);
 
 DWORD
+WnbdStats(PCHAR instanceName);
+
+DWORD
 WnbdMap(PCHAR InstanceName,
         PCHAR HostName,
         PCHAR PortName,

--- a/userspace/userspace/main.cpp
+++ b/userspace/userspace/main.cpp
@@ -47,6 +47,9 @@ int main(int argc, PCHAR argv[])
     } else if (argc == 3 && !strcmp(Command, "unmap")) {
         InstanceName = argv[2];
         WnbdUnmap(InstanceName);
+    } else if (argc == 3 && !strcmp(Command, "stats")) {
+        InstanceName = argv[2];
+        WnbdStats(InstanceName);
     } else if (argc == 2 && !strcmp(Command, "list")) {
         PDISK_INFO_LIST Output = NULL;
         DWORD Status = WnbdList(&Output);

--- a/vstudio/reinstall.ps1
+++ b/vstudio/reinstall.ps1
@@ -33,6 +33,6 @@ if ($status -eq $false) {
 & $devconBin remove "root\wnbd"
 
 pnputil.exe /enum-drivers | sls -Context 5 wnbd | findstr Published | `
-    % {$_ -match "(oem\d+.inf)"; pnputil.exe /delete-driver $matches[0] }
+    % {$_ -match "(oem\d+.inf)"; pnputil.exe /delete-driver $matches[0] /force }
 
 & $devconBin install $wnbdInf root\wnbd


### PR DESCRIPTION
At the moment, we're sending one NBD request at a time and wait for
it to complete. While simple, this is very inefficient.

This change will send the requests as they arrive, using a separate
thread to read the replies from the NBD channel. We'll limit
the maximum number of in-flight requests, using a hard-coded value
of 255 for the time being.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>
Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>