### PR TITLE
Add read-only mode

### DIFF
--- a/driver/rbd_protocol.h
+++ b/driver/rbd_protocol.h
@@ -7,13 +7,24 @@
 #ifndef RBD_PROTOCOL_H
 #define RBD_PROTOCOL_H 1
 
-#include "common.h"
-
 #define NBD_REQUEST_MAGIC 0x25609513
 #define NBD_REPLY_MAGIC   0x67446698
 
 #define NBD_REQUEST_MAGIC 0x25609513
 #define NBD_REPLY_MAGIC   0x67446698
+
+/* values for flags field, these are server interaction specific. */
+#define NBD_FLAG_HAS_FLAGS  (1 << 0) /* nbd-server supports flags */
+#define NBD_FLAG_READ_ONLY  (1 << 1) /* device is read-only */
+#define NBD_FLAG_SEND_FLUSH (1 << 2) /* can flush writeback cache */
+#define NBD_FLAG_SEND_FUA   (1 << 3) /* send FUA (forced unit access) */
+/* there is a gap here to match userspace */
+#define NBD_FLAG_SEND_TRIM  (1 << 5) /* send trim/discard */
+#define NBD_FLAG_CAN_MULTI_CONN (1 << 8) /* Server supports multiple connections per export. */
+
+/* values for cmd flags in the upper 16 bits of request type */
+#define NBD_CMD_FLAG_FUA    (1 << 16) /* FUA (forced unit access) op */
+
 
 enum {
     NBD_CMD_READ = 0,

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -311,10 +311,10 @@ WnbdCreateConnection(PGLOBAL_INFORMATION GInfo,
         goto ExitInquiryData;
     }
 
+    UINT16 RbdFlags = 0;
     if (Info->MustNegotiate) {
         WNBD_LOG_INFO("Trying to negotiate handshake with RBD Server");
         Info->DiskSize = 0;
-        UINT16 RbdFlags = 0;
         Status = RbdNegotiate(&Sock, &Info->DiskSize, &RbdFlags, Info->ExportName, 1, 1);
         if (!NT_SUCCESS(Status)) {
             goto ExitInquiryData;
@@ -322,6 +322,12 @@ WnbdCreateConnection(PGLOBAL_INFORMATION GInfo,
         WNBD_LOG_INFO("Negotiated disk size: %llu", Info->DiskSize);
         NewEntry->DiskSize = Info->DiskSize;
     }
+
+    NewEntry->NbdFlags = Info->NbdFlags | RbdFlags;
+    // For convenience, we'll use another field.
+    NewEntry->ReadOnly = NewEntry->NbdFlags & (
+        NBD_FLAG_HAS_FLAGS | NBD_FLAG_READ_ONLY);
+
     ULONG TargetId = bitNumber % SCSI_MAXIMUM_TARGETS_PER_BUS;
     ULONG BusId = bitNumber / MAX_NUMBER_OF_SCSI_TARGETS;
 

--- a/driver/userspace.h
+++ b/driver/userspace.h
@@ -28,6 +28,8 @@ typedef struct _USER_ENTRY {
     BOOLEAN                            Connected;
     UINT64                             DiskSize;
     UINT16                             BlockSize;
+    UINT16                             NbdFlags;
+    BOOLEAN                            ReadOnly;
     CONNECTION_INFO                    UserInformation;
 } USER_ENTRY, *PUSER_ENTRY;
 

--- a/driver/userspace_shared.h
+++ b/driver/userspace_shared.h
@@ -41,6 +41,7 @@ typedef struct _CONNECTION_INFO {
     INT             Pid;
     UINT64          DiskSize;
     UINT16          BlockSize;
+    UINT16          NbdFlags;
 } CONNECTION_INFO, * PCONNECTION_INFO;
 
 typedef struct _WNBD_COMMAND {

--- a/userspace/userspace/ioctl.h
+++ b/userspace/userspace/ioctl.h
@@ -39,7 +39,8 @@ WnbdMap(PCHAR InstanceName,
         PCHAR PortName,
         PCHAR ExportName,
         UINT64 DiskSize,
-        BOOLEAN Removable);
+        BOOLEAN MustNegotiate,
+        BOOLEAN ReadOnly);
 
 DWORD
 WnbdList(PDISK_INFO_LIST* Output);

--- a/userspace/userspace/main.cpp
+++ b/userspace/userspace/main.cpp
@@ -24,6 +24,12 @@ std::wstring to_wstring(std::string str)
     return strconverter.from_bytes(str);
 }
 
+bool arg_to_bool(char* arg) {
+    return !_stricmp(arg, "1") ||
+           !_stricmp(arg, "yes") ||
+           !_stricmp(arg, "y");
+}
+
 int main(int argc, PCHAR argv[])
 {
     PCHAR Command;
@@ -40,10 +46,16 @@ int main(int argc, PCHAR argv[])
         PortName = argv[4];
         ExportName = argv[5];
         BOOLEAN MustNegotiate = TRUE;
-        if (argc == 7) {
+        BOOLEAN ReadOnly = FALSE;
+
+        if (argc > 6 && arg_to_bool(argv[6])) {
             MustNegotiate = FALSE;
         }
-        WnbdMap(InstanceName, HostName, PortName, ExportName, 50000, MustNegotiate);
+        if (argc > 7 && arg_to_bool(argv[7])) {
+            ReadOnly = FALSE;
+        }
+        WnbdMap(InstanceName, HostName, PortName, ExportName, 50000,
+                MustNegotiate, ReadOnly);
     } else if (argc == 3 && !strcmp(Command, "unmap")) {
         InstanceName = argv[2];
         WnbdUnmap(InstanceName);


### PR DESCRIPTION
This change will allow passing NBD flags. For now, we're only using
the read-only flag. In the future, we'll also detect and use
TRIM support.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>