### PR TITLE
Update library name in DEF file

### DIFF
--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -1,4 +1,4 @@
-LIBRARY wnbd
+LIBRARY libwnbd
 
 EXPORTS
     WnbdCreate


### PR DESCRIPTION
MSVC complains:
https://ci.appveyor.com/project/aserdean/wnbd/branch/master/job/9i0gd0blgdj446vr#L194
```
warning LNK4070: /OUT:wnbd.dll directive in .EXP differs from output filename
```

Change library name from wnbd to libwnd in the DEF file

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>