### PR TITLE
Code analysis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ branches:
   only:
   - master
 configuration:
+  - Analyze
   - Debug
   - Release
 clone_folder: C:\wnbd

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -22,6 +22,7 @@ extern UINT32 GlobalLogLevel = 0;
 
 extern PGLOBAL_INFORMATION GlobalInformation;
 
+_Use_decl_annotations_
 BOOLEAN
 WNBDReadRegistryValue(PUNICODE_STRING RegistryPath,
                       PWSTR Key,

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -17,6 +17,7 @@
 #define WNBD_INQUIRY_PRODUCT_REVISION    "V0.1"
 #define WNBD_INQUIRY_VENDOR_SPECIFIC     "WNBD_DISK_SPECIFIC_VENDOR_STRING"
 
+_Success_(return)
 BOOLEAN
 WNBDReadRegistryValue(_In_ PUNICODE_STRING RegistryPath,
                       _In_ PWSTR Key,

--- a/driver/nbd_protocol.h
+++ b/driver/nbd_protocol.h
@@ -143,7 +143,7 @@ NbdNegotiate(_In_ INT* Pfd,
 
 NTSTATUS
 NbdReadReply(_In_ INT Fd,
-             _Out_ PNBD_REPLY Reply);
+             _Inout_ PNBD_REPLY Reply);
 #pragma alloc_text (PAGE, NbdReadReply)
 
 INT

--- a/driver/util.c
+++ b/driver/util.c
@@ -598,7 +598,11 @@ WnbdProcessDeviceThreadReplies(_In_ PSCSI_DEVICE_INFORMATION DeviceInformation)
             goto Exit;
         } else {
             if(!Element->Aborted) {
+                // SrbBuff can't be NULL
+#pragma warning(push)
+#pragma warning(disable:6387)
                 RtlCopyMemory(SrbBuff, TempBuff, Element->ReadLength);
+#pragma warning(pop)
             }
         }
     }

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -317,7 +317,11 @@ NTSTATUS WnbdHandleResponse(
 
         // TODO: compare data buffer size with the read length
         if (!Element->Aborted) {
+            // SrbBuff can't be NULL
+#pragma warning(push)
+#pragma warning(disable:6387)
             RtlCopyMemory(SrbBuff, LockedUserBuff, Element->ReadLength);
+#pragma warning(pop)
         }
     }
     if (Response->Status.ScsiStatus) {

--- a/ksocket_wsk/ksocket_wsk.vcxproj
+++ b/ksocket_wsk/ksocket_wsk.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Analyze|x64">
+      <Configuration>Analyze</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -46,6 +50,14 @@
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -61,6 +73,11 @@
     <IncludePath>$(ProjectDir);$(VC_IncludePath);$(IncludePath);$(KMDF_INC_PATH)$(KMDF_VER_PATH)</IncludePath>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
+    <IncludePath>$(ProjectDir);$(VC_IncludePath);$(IncludePath);$(KMDF_INC_PATH)$(KMDF_VER_PATH)</IncludePath>
+    <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -69,6 +86,11 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/libwnbd/libwnbd.vcxproj
+++ b/libwnbd/libwnbd.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Analyze|x64">
+      <Configuration>Analyze</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -41,6 +45,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -52,12 +63,19 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -78,6 +96,28 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;WNBDDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\driver\;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
+      <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Analyze|x64">
+      <Configuration>Analyze</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -35,6 +39,13 @@
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -57,6 +68,14 @@
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <TargetName>wnbd</TargetName>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
+    <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -69,6 +88,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/vstudio/wnbd.sln
+++ b/vstudio/wnbd.sln
@@ -18,26 +18,35 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libwnbd", "..\libwnbd\libwn
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Analyze|x64 = Analyze|x64
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Analyze|x64.ActiveCfg = Analyze|x64
+		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Analyze|x64.Build.0 = Analyze|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Debug|x64.ActiveCfg = Debug|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Debug|x64.Build.0 = Debug|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Debug|x64.Deploy.0 = Debug|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Release|x64.ActiveCfg = Release|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Release|x64.Build.0 = Release|x64
 		{0091FAE6-479E-40CB-985E-1AC3FB633391}.Release|x64.Deploy.0 = Release|x64
+		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Analyze|x64.ActiveCfg = Analyze|x64
+		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Analyze|x64.Build.0 = Analyze|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Debug|x64.ActiveCfg = Debug|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Debug|x64.Build.0 = Debug|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Debug|x64.Deploy.0 = Debug|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Release|x64.ActiveCfg = Release|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Release|x64.Build.0 = Release|x64
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E}.Release|x64.Deploy.0 = Release|x64
+		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Analyze|x64.ActiveCfg = Analyze|x64
+		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Analyze|x64.Build.0 = Analyze|x64
 		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Debug|x64.ActiveCfg = Debug|x64
 		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Debug|x64.Build.0 = Debug|x64
 		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Release|x64.ActiveCfg = Release|x64
 		{A9A19AD0-D8F6-4D41-9B82-375370C408D7}.Release|x64.Build.0 = Release|x64
+		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Analyze|x64.ActiveCfg = Analyze|x64
+		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Analyze|x64.Build.0 = Analyze|x64
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Debug|x64.ActiveCfg = Debug|x64
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Debug|x64.Build.0 = Debug|x64
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Release|x64.ActiveCfg = Release|x64

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Analyze|x64">
+      <Configuration>Analyze</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -31,6 +35,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -42,11 +53,20 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>wnbd-client</TargetName>
     <IntDir>$(Platform)\$(Configuration)\obj\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>wnbd-client</TargetName>
+    <IntDir>$(Platform)\$(Configuration)\obj\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -54,6 +74,28 @@
     <IntDir>$(Platform)\$(Configuration)\obj\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\driver\;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>


### PR DESCRIPTION
This PR addresses code analysis warnings found in `driver` project.

Adds a new configuration called `Analysis` so the Microsoft code analyzer is ran, with the default rule set, when building the project.

Also update appveyor matrix so we can see potential defects.

A sample output can be viewed here:
https://ci.appveyor.com/project/aserdean/wnbd-1/build/job/f382y7rx6ygidm91#L251