### PR TITLE
appveyor: Run SDV on Analyze configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,17 @@ init:
 - ps: New-Item -Type HardLink -Path "C:\Python37\python3.exe" -Value "C:\Python37\python.exe"
 
 build_script:
-- '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat"'
+- '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
 - msbuild C:\wnbd\vstudio\wnbd.sln /property:Configuration=%CONFIGURATION%
+- ps: |
+    if ($env:CONFIGURATION -eq "Analyze") {
+      pushd
+      cd C:\wnbd\vstudio\;
+      msbuild driver.vcxproj /t:sdv /p:inputs="/check" /p:configuration="Analyze" /p:platform="x64" /p:SolutionDir="C:\wnbd\vstudio\"
+      popd
+      # The catalog file is lost when using SDV
+      msbuild C:\wnbd\vstudio\wnbd.sln /property:Configuration="Analyze"
+    }
 - copy C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\* .
 - 7z a wnbd-%CONFIGURATION%.zip C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.cat C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.inf C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.sys C:\wnbd\vstudio\x64\%CONFIGURATION%\wnbd-client.exe
 


### PR DESCRIPTION
This patch adds Static Driver Verifier check on the `Release` configuration.

SDV fails to run with `vcvarsx86_amd64`, switch to amd64 only.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>

---
Appveyor build for reference: (1) https://ci.appveyor.com/project/aserdean/wnbd-1/builds/35228190
                                             (2) https://ci.appveyor.com/project/aserdean/wnbd-1/builds/35228190/job/tedpc6m4yq9ywa9r#L399