### PR TITLE
Add versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ tags
 /vstudio/x64/
 /vstudio/sdv/
 /vstudiox64/
+
+include/version.h

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -136,6 +136,10 @@ DWORD WnbdGetConnectionInfo(
 
 DWORD WnbdRaiseLogLevel(USHORT LogLevel);
 
+// Get libwnbd version.
+DWORD WnbdGetLibVersion(PWNBD_VERSION Version);
+DWORD WnbdGetDriverVersion(PWNBD_VERSION Version);
+
 // Setting the SCSI SENSE data provides detailed information about
 // the status of a request.
 void WnbdSetSenseEx(
@@ -176,6 +180,7 @@ DWORD WnbdIoctlStats(
     PWNBD_DRV_STATS Stats);
 // Reload the persistent settings provided through registry keys.
 DWORD WnbdIoctlReloadConfig(HANDLE Device);
+DWORD WnbdIoctlVersion(HANDLE Device, PWNBD_VERSION Version);
 
 // The connection id should be handled carefully in order to avoid delayed replies
 // from being submitted to other disks after being remapped.

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -11,6 +11,7 @@
 #define IOCTL_WNBD_LIST 6
 #define IOCTL_WNBD_STATS 7
 #define IOCTL_WNBD_RELOAD_CONFIG 8
+#define IOCTL_WNBD_VERSION 9
 
 static const GUID WNBD_GUID = {
     0x949dd17c,
@@ -21,6 +22,7 @@ static const GUID WNBD_GUID = {
 
 #define WNBD_MAX_NAME_LENGTH 256
 #define WNBD_MAX_OWNER_LENGTH 16
+#define WNBD_MAX_VERSION_STR_LENGTH 128
 // For transfers larger than 16MB, Storport sends 0 sized buffers.
 #define WNBD_DEFAULT_MAX_TRANSFER_LENGTH 2 * 1024 * 1024
 
@@ -212,6 +214,9 @@ typedef PWNBD_IOCTL_BASE_COMMAND PWNBD_IOCTL_LIST_COMMAND;
 typedef WNBD_IOCTL_BASE_COMMAND WNBD_IOCTL_RELOAD_CONFIG_COMMAND;
 typedef PWNBD_IOCTL_BASE_COMMAND PWNBD_IOCTL_RELOAD_CONFIG_COMMAND;
 
+typedef WNBD_IOCTL_BASE_COMMAND WNBD_IOCTL_VERSION_COMMAND;
+typedef PWNBD_IOCTL_BASE_COMMAND PWNBD_IOCTL_VERSION_COMMAND;
+
 typedef struct
 {
     ULONG IoControlCode;
@@ -278,5 +283,13 @@ static inline const CHAR* WnbdRequestTypeToStr(WnbdRequestType RequestType) {
             return "UNKNOWN";
     }
 }
+
+typedef struct {
+    UINT32 Major;
+    UINT32 Minor;
+    UINT32 Patch;
+    CHAR Description[WNBD_MAX_VERSION_STR_LENGTH];
+    BYTE Reserved[256];
+} WNBD_VERSION, *PWNBD_VERSION;
 
 #endif // WNBD_IOCTL_H

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -7,6 +7,7 @@
 
 #include "wnbd.h"
 #include "wnbd_wmi.h"
+#include "version.h"
 
 #define STRING_OVERFLOWS(Str, MaxLen) (strlen(Str + 1) > MaxLen)
 
@@ -208,6 +209,35 @@ DWORD WnbdGetDriverStats(
     }
 
     Status = WnbdIoctlStats(Handle, InstanceName, Stats);
+
+    CloseHandle(Handle);
+    return Status;
+}
+
+DWORD WnbdGetLibVersion(PWNBD_VERSION Version)
+{
+    if (!Version) {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    Version->Major = WNBD_VERSION_MAJOR;
+    Version->Minor = WNBD_VERSION_MINOR;
+    Version->Patch = WNBD_VERSION_PATCH;
+    strncpy_s((char*)&Version->Description, WNBD_MAX_VERSION_STR_LENGTH,
+              WNBD_VERSION_STR,
+              min(strlen(WNBD_VERSION_STR), WNBD_MAX_VERSION_STR_LENGTH - 1));
+    return 0;
+}
+
+DWORD WnbdGetDriverVersion(PWNBD_VERSION Version)
+{
+    HANDLE Handle = INVALID_HANDLE_VALUE;
+    DWORD Status = WnbdOpenDevice(&Handle);
+    if (Status) {
+        return ERROR_OPEN_FAILED;
+    }
+
+    Status = WnbdIoctlVersion(Handle, Version);
 
     CloseHandle(Handle);
     return Status;

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -17,6 +17,8 @@ EXPORTS
     WnbdCoInitializeBasic
     WnbdGetDiskNumberBySerialNumber
     WnbdGetConnectionInfo
+    WnbdGetDriverVersion
+    WnbdGetLibVersion
 
     WnbdOpenDevice
     WnbdIoctlPing

--- a/libwnbd/libwnbd.vcxproj
+++ b/libwnbd/libwnbd.vcxproj
@@ -94,6 +94,9 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -116,6 +119,9 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -138,6 +144,9 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/libwnbd/wnbd_ioctl.c
+++ b/libwnbd/wnbd_ioctl.c
@@ -288,3 +288,22 @@ DWORD WnbdIoctlPing(HANDLE Device)
     return ERROR_SUCCESS;
 }
 
+DWORD WnbdIoctlVersion(HANDLE Device, PWNBD_VERSION Version)
+{
+    DWORD Status = ERROR_SUCCESS;
+    DWORD BytesReturned = 0;
+
+    WNBD_IOCTL_VERSION_COMMAND Command = { 0 };
+    Command.IoControlCode = IOCTL_WNBD_VERSION;
+
+    BOOL DevStatus = DeviceIoControl(
+        Device, IOCTL_MINIPORT_PROCESS_SERVICE_IRP,
+        &Command, sizeof(Command),
+        Version, sizeof(WNBD_VERSION), &BytesReturned, NULL);
+
+    if (!DevStatus) {
+        Status = GetLastError();
+    }
+
+    return Status;
+}

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -86,6 +86,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;$(DDK_LIB_PATH )libcntpr.lib;$(DDK_LIB_PATH )wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -95,6 +98,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -104,6 +110,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="..\driver\wnbd.inf" />

--- a/vstudio/generate_version_h.ps1
+++ b/vstudio/generate_version_h.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+
+$scriptLocation = [System.IO.Path]::GetDirectoryName(
+    $myInvocation.MyCommand.Definition)
+
+$versionHeaderPath = "$scriptLocation/../include/version.h"
+
+$gitShortDesc = git describe --tags
+$gitLongDesc = git describe --tags --long
+$gitTag = git describe --tags --abbrev=0
+
+$isDev = (($gitLongDesc) -split "-")[-2] -ne "0"
+
+$gitTag -match "(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)"
+if ($Matches.Count -ne 4) {
+    throw "Invalid version tag: $gitTag. Expecting a semantic version, such as '1.0.0-beta'."
+}
+
+$versionMajor = $Matches.major
+$versionMinor = $Matches.minor
+$versionPatch = $Matches.patch
+$versionStr = "$gitShortDesc"
+
+# We might add some more info to the version string.
+$versionStrMaxLen = 127
+$versionStrLen = $versionStr.Length
+if ($versionStrLen -gt 127) {
+    throw "Version string too large. Length: $versionStrLen, maximum length: $versionStrMaxLen."
+}
+
+$versionHeader = @"
+// Automatically generated using generate_version_h.ps1 at build time.
+
+#pragma once
+
+#define WNBD_VERSION_MAJOR ${versionMajor}
+#define WNBD_VERSION_MINOR ${versionMinor}
+#define WNBD_VERSION_PATCH ${versionPatch}
+
+#define WNBD_VERSION_STR "${versionStr}"
+"@
+
+echo $versionHeader | out-file -encoding utf8 -filepath $versionHeaderPath

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -7,6 +7,7 @@
 #include "cmd.h"
 #include "wnbd.h"
 #include "nbd_protocol.h"
+#include "version.h"
 
 #include <string>
 #include <codecvt>
@@ -23,6 +24,7 @@ std::wstring to_wstring(std::string str)
 void PrintSyntax()
 {
     fprintf(stderr, "Syntax:\n");
+    fprintf(stderr, "wnbd-client -v\n");
     fprintf(stderr, "wnbd-client map  <InstanceName> <HostName> "
                     "<PortName> <ExportName> [<SkipNBDNegotiation> "
                     "<ReadOnly> <DiskSize> <BlockSize>]\n");
@@ -262,5 +264,25 @@ DWORD CmdRaiseLogLevel(UINT32 LogLevel)
         fprintf(stderr, "Could not get connection list.\n");
         PrintFormattedError(Status);
     }
+    return Status;
+}
+
+DWORD CmdVersion() {
+    printf("wnbd-client.exe: %s\n", WNBD_VERSION_STR);
+
+    WNBD_VERSION Version = { 0 };
+    WnbdGetLibVersion(&Version);
+    printf("libwnbd.dll: %s\n", Version.Description);
+
+    Version = { 0 };
+    DWORD Status = WnbdGetDriverVersion(&Version);
+    if (Status) {
+        fprintf(stderr, "Could not get WNBD driver version.\n");
+        PrintFormattedError(Status);
+    }
+    else {
+        printf("wnbd.sys: %s\n", Version.Description);
+    }
+
     return Status;
 }

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -52,6 +52,9 @@ CmdList();
 DWORD
 CmdRaiseLogLevel(UINT32 LogLevel);
 
+DWORD
+CmdVersion();
+
 #ifdef __cplusplus
 }
 #endif

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, PCHAR argv[])
 
         CmdMap(InstanceName, HostName, PortNumber, ExportName, DiskSize,
                BlockSize, SkipNegotiation, ReadOnly);
-    } else if (argc == 3 && !strcmp(Command, "unmap")) {
+    } else if (argc >= 3 && !strcmp(Command, "unmap")) {
         InstanceName = argv[2];
         BOOLEAN HardRemove = FALSE;
         if (argc > 3) {
@@ -65,6 +65,9 @@ int main(int argc, PCHAR argv[])
         return CmdList();
     } else if (argc == 3 && !strcmp(Command, "set-debug")) {
         CmdRaiseLogLevel(arg_to_bool(argv[2]));
+    } else if (argc == 2 && (
+            !strcmp(Command, "version") || !strcmp(Command, "-v"))) {
+        return CmdVersion();
     } else {
         PrintSyntax();
         return -1;

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -94,6 +94,9 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -116,6 +119,9 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -134,6 +140,9 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="cmd.cpp" />


### PR DESCRIPTION
We'll use semantic versioning, which will be set through git tags.

For now, a script will be run as a pre-build event, parsing the git
tag and generating version.h.

wnbd-client -v will return the wnbd-client, the libwnbd as well as
the driver version.

We're using the "git describe" short version, which includes the
commit id and offset for untagged commits. If needed, we can easily
add other version info (e.g. build type, architecture, etc).

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>