### PR TITLE
Add SDV check as post build action

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,6 @@ init:
 build_script:
 - '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
 - msbuild C:\wnbd\vstudio\wnbd.sln /property:Configuration=%CONFIGURATION%
-- ps: |
-    if ($env:CONFIGURATION -eq "Analyze") {
-      pushd
-      cd C:\wnbd\vstudio\;
-      msbuild driver.vcxproj /t:sdv /p:inputs="/check" /p:configuration="Analyze" /p:platform="x64" /p:SolutionDir="C:\wnbd\vstudio\"
-      popd
-      # The catalog file is lost when using SDV
-      msbuild C:\wnbd\vstudio\wnbd.sln /property:Configuration="Analyze"
-    }
 - copy C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\* .
 - 7z a wnbd-%CONFIGURATION%.zip C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.cat C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.inf C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.sys C:\wnbd\vstudio\x64\%CONFIGURATION%\wnbd-client.exe
 

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -99,7 +99,7 @@
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
+      <Command>powershell.exe -executionpolicy bypass $(SolutionDir)\generate_version_h.ps1</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
@@ -113,6 +113,9 @@
     <PreBuildEvent>
       <Command>powershell.exe -executionpolicy bypass $(SolutionDir)generate_version_h.ps1</Command>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>powershell.exe -executionpolicy bypass -command $env:VCINSTALLDIR='$(VCInstallDir)'; cd $(SolutionDir); msbuild $(SolutionFileName) /p:Configuration=Release; msbuild $(ProjectFileName) /t:sdv /p:inputs='/check' /p:Configuration=Release /p:SolutionDir=$(SolutionDir); msbuild $(ProjectFileName) /p:Configuration=Release /P:RunCodeAnalysisOnce=True</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="..\driver\wnbd.inf" />


### PR DESCRIPTION
This patch adds a new build action on the `Analyze` property which will
run SDV. During the SDV process paths are mangled and an extra `\` is needed
when building the `Release` build.

This patch also removes unneeded appveyor step.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>