### PR TITLE
userspace: update logging

### DIFF
--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -1,6 +1,7 @@
 #ifndef WNBD_SHARED_H
 #define WNBD_SHARED_H
 
+#include <windows.h>
 #include <cfgmgr32.h>
 
 #include "wnbd_ioctl.h"
@@ -69,7 +70,6 @@ typedef struct _WNBD_DEVICE
     PVOID Context;
     WNBD_PROPERTIES Properties;
     WNBD_CONNECTION_INFO ConnectionInfo;
-    WnbdLogLevel LogLevel;
     const WNBD_INTERFACE *Interface;
     BOOLEAN Stopping;
     BOOLEAN Stopped;
@@ -104,7 +104,6 @@ typedef VOID (*UnmapFunc)(
     PWNBD_UNMAP_DESCRIPTOR Descriptors,
     UINT32 Count);
 typedef VOID (*LogMessageFunc)(
-    PWNBD_DEVICE Device,
     WnbdLogLevel LogLevel,
     const char* Message,
     const char* FileName,
@@ -120,15 +119,13 @@ typedef struct _WNBD_INTERFACE
     WriteFunc Write;
     FlushFunc Flush;
     UnmapFunc Unmap;
-    LogMessageFunc LogMessage;
-    VOID* Reserved[14];
+    VOID* Reserved[15];
 } WNBD_INTERFACE, *PWNBD_INTERFACE;
 
 DWORD WnbdCreate(
     const PWNBD_PROPERTIES Properties,
     const PWNBD_INTERFACE Interface,
     PVOID Context,
-    WnbdLogLevel LogLevel,
     PWNBD_DEVICE* PDevice);
 // Remove the disk. The existing dispatchers will continue running until all
 // the driver IO requests are completed unless the "HardRemove" flag is set.
@@ -161,7 +158,11 @@ DWORD WnbdGetConnectionInfo(
     PWNBD_DEVICE Device,
     PWNBD_CONNECTION_INFO ConnectionInfo);
 
-DWORD WnbdRaiseLogLevel(USHORT LogLevel);
+// libwnbd logger
+VOID WnbdSetLogger(LogMessageFunc Logger);
+VOID WnbdSetLogLevel(WnbdLogLevel LogLevel);
+
+DWORD WnbdRaiseDrvLogLevel(USHORT LogLevel);
 
 // Get libwnbd version.
 DWORD WnbdGetLibVersion(PWNBD_VERSION Version);

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -9,7 +9,9 @@ EXPORTS
     WnbdShow
     WnbdGetUserspaceStats
     WnbdGetDriverStats
-    WnbdRaiseLogLevel
+    WnbdSetLogger
+    WnbdSetLogLevel
+    WnbdRaiseDrvLogLevel
     WnbdSetSenseEx
     WnbdSetSense
     WnbdStartDispatcher

--- a/libwnbd/libwnbd.vcxproj
+++ b/libwnbd/libwnbd.vcxproj
@@ -15,13 +15,17 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="wnbd_ioctl.c" />
     <ClCompile Include="libwnbd.cpp" />
+    <ClCompile Include="utils.cpp" />
+    <ClCompile Include="wnbd_ioctl.cpp" />
+    <ClCompile Include="wnbd_log.c" />
     <ClCompile Include="wnbd_wmi.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\wnbd.h" />
     <ClInclude Include="..\include\wnbd_ioctl.h" />
+    <ClInclude Include="utils.h" />
+    <ClInclude Include="wnbd_log.h" />
     <ClInclude Include="wnbd_wmi.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/libwnbd/libwnbd.vcxproj.filters
+++ b/libwnbd/libwnbd.vcxproj.filters
@@ -15,13 +15,19 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="wnbd_ioctl.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="wnbd_wmi.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="libwnbd.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wnbd_log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wnbd_ioctl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="utils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -33,6 +39,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\wnbd_ioctl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wnbd_log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libwnbd/utils.cpp
+++ b/libwnbd/utils.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include <codecvt>
+#include <locale>
+#include <string>
+#include <sstream>
+
+#include <windows.h>
+
+std::wstring to_wstring(const char* str)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
+    return strconverter.from_bytes(str);
+}
+
+std::string to_string(std::wstring wstr)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
+    return strconverter.to_bytes(wstr);
+}
+
+std::string win32_strerror(int err)
+{
+    LPSTR msg = NULL;
+    DWORD msg_len = ::FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        err,
+        0,
+        (LPSTR) &msg,
+        0,
+        NULL);
+    if (!msg_len) {
+        std::ostringstream msg_stream;
+        msg_stream << "Unknown error (" << err << ").";
+        return msg_stream.str();
+    }
+    std::string msg_s(msg);
+    ::LocalFree(msg);
+    return msg_s;
+}

--- a/libwnbd/utils.h
+++ b/libwnbd/utils.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string>
+
+std::wstring to_wstring(const char* str);
+std::string to_string(std::wstring wstr);
+std::string win32_strerror(int err);

--- a/libwnbd/wnbd_log.c
+++ b/libwnbd/wnbd_log.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include <stdio.h>
+
+#include "wnbd_log.h"
+#include "wnbd.h"
+
+VOID ConsoleLogger(
+    WnbdLogLevel LogLevel,
+    const char* Message,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName)
+{
+    fprintf(stderr, "libwnbd.dll!%s %s %s\n",
+            FunctionName, WnbdLogLevelToStr(LogLevel), Message);
+}
+
+static LogMessageFunc WnbdCurrLogger = ConsoleLogger;
+static WnbdLogLevel WnbdCurrLogLevel = WnbdLogLevelWarning;
+
+VOID LogMessage(WnbdLogLevel LogLevel,
+                const char* FileName, UINT32 Line, const char* FunctionName,
+                const char* Format, ...)
+{
+    LogMessageFunc CurrLogger = WnbdCurrLogger;
+    WnbdLogLevel CurrLogLevel = WnbdCurrLogLevel;
+
+    if (!CurrLogger || CurrLogLevel < LogLevel)
+        return;
+
+    va_list Args;
+    va_start(Args, Format);
+
+    size_t BufferLength = (size_t)_vscprintf(Format, Args) + 1;
+
+    // TODO: consider enforcing WNBD_LOG_MESSAGE_MAX_SIZE and using a fixed
+    // size buffer for performance reasons.
+    char* Buff = (char*) malloc(BufferLength);
+    if (!Buff)
+        return;
+
+    vsnprintf_s(Buff, BufferLength, BufferLength - 1, Format, Args);
+    va_end(Args);
+
+    CurrLogger(LogLevel, Buff, FileName, Line, FunctionName);
+
+    free(Buff);
+}
+
+VOID WnbdSetLogger(LogMessageFunc Logger)
+{
+    // Passing NULL should allow completely disabling the logger.
+    WnbdCurrLogger = Logger;
+}
+
+VOID WnbdSetLogLevel(WnbdLogLevel LogLevel)
+{
+    WnbdCurrLogLevel = LogLevel;
+}

--- a/libwnbd/wnbd_log.h
+++ b/libwnbd/wnbd_log.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include "wnbd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+VOID ConsoleLogger(
+    WnbdLogLevel LogLevel,
+    const char* Message,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName);
+
+VOID LogMessage(
+    WnbdLogLevel LogLevel,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName,
+    const char* Format, ...);
+
+#define LogCritical(Format, ...) \
+    LogMessage(WnbdLogLevelCritical, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogError(Format, ...) \
+    LogMessage(WnbdLogLevelError, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogWarning(Format, ...) \
+    LogMessage(WnbdLogLevelWarning, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogInfo(Format, ...) \
+    LogMessage(WnbdLogLevelInfo, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogDebug(Format, ...) \
+    LogMessage(WnbdLogLevelDebug, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogTrace(Format, ...) \
+    LogMessage(WnbdLogLevelTrace, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -29,7 +29,6 @@ int main(int argc, PCHAR argv[])
     // possible to avoid having issues because of uninitialized COM.
     HRESULT hres = WnbdCoInitializeBasic();
     if (FAILED(hres)) {
-        fprintf(stderr, "Failed to initialize COM. HRESULT: 0x%x.\n", hres);
         return HRESULT_CODE(hres);
     }
 


### PR DESCRIPTION
userspace: update logging

We allow the library consumer to provide a logger function.
This is really convenient because the consumer can choose how those
messages will be handled (e.g. can use ETW or simple file logging,
can format the messages, etc).

The main issue is that the logger is tied to the WNBD_DEVICE
structure, which limits its usefulness since we can't use it
in functions that don't accept this parameter.

This change will add a static logger function pointer, allowing
the consumer to override it using a setter.

This commit also adds log messages to all the functions that couldn't
use logging before.

Depends-On: https://github.com/cloudbase/wnbd/pull/23