### PR TITLE
Disambiguate device parameters

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -201,7 +201,7 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
             }
 
             WNBD_LOG_INFO("Removing device.");
-            PWNBD_SCSI_DEVICE Device = WnbdFindDeviceByAddr(
+            PWNBD_DISK_DEVICE Device = WnbdFindDeviceByAddr(
                 GlobalExt, ScsiAddress.PathId,
                 ScsiAddress.TargetId, ScsiAddress.Lun, TRUE);
             if (!Device) {

--- a/driver/nbd_dispatch.c
+++ b/driver/nbd_dispatch.c
@@ -36,7 +36,7 @@ ScsiOpToNbdReqType(int ScsiOp)
 }
 
 NTSTATUS
-WnbdRequestWrite(_In_ PWNBD_SCSI_DEVICE Device,
+WnbdRequestWrite(_In_ PWNBD_DISK_DEVICE Device,
                  _In_ PSRB_QUEUE_ELEMENT Element,
                  _In_ DWORD NbdTransmissionFlags)
 {
@@ -69,7 +69,7 @@ WnbdRequestWrite(_In_ PWNBD_SCSI_DEVICE Device,
 }
 
 VOID
-WnbdProcessDeviceThreadRequests(_In_ PWNBD_SCSI_DEVICE Device)
+WnbdProcessDeviceThreadRequests(_In_ PWNBD_DISK_DEVICE Device)
 {
     WNBD_LOG_LOUD(": Enter");
     ASSERT(Device);
@@ -161,7 +161,7 @@ NbdDeviceRequestThread(_In_ PVOID Context)
 
     KeSetPriorityThread(KeGetCurrentThread(), LOW_REALTIME_PRIORITY);
 
-    PWNBD_SCSI_DEVICE Device = (PWNBD_SCSI_DEVICE) Context;
+    PWNBD_DISK_DEVICE Device = (PWNBD_DISK_DEVICE) Context;
     while (!Device->HardRemoveDevice) {
         PVOID WaitObjects[2];
         WaitObjects[0] = &Device->DeviceEvent;
@@ -195,7 +195,7 @@ NbdDeviceReplyThread(_In_ PVOID Context)
 
     KeSetPriorityThread(KeGetCurrentThread(), LOW_REALTIME_PRIORITY);
 
-    PWNBD_SCSI_DEVICE Device = (PWNBD_SCSI_DEVICE) Context;
+    PWNBD_DISK_DEVICE Device = (PWNBD_DISK_DEVICE) Context;
     while (!Device->HardRemoveDevice) {
         NbdProcessDeviceThreadReplies(Device);
     }
@@ -204,7 +204,7 @@ NbdDeviceReplyThread(_In_ PVOID Context)
 }
 
 VOID
-NbdProcessDeviceThreadReplies(_In_ PWNBD_SCSI_DEVICE Device)
+NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device)
 {
     WNBD_LOG_LOUD(": Enter");
     ASSERT(Device);

--- a/driver/nbd_dispatch.h
+++ b/driver/nbd_dispatch.h
@@ -14,4 +14,4 @@ VOID
 NbdDeviceReplyThread(_In_ PVOID Context);
 #pragma alloc_text (PAGE, NbdDeviceReplyThread)
 VOID
-NbdProcessDeviceThreadReplies(_In_ PWNBD_SCSI_DEVICE Device);
+NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device);

--- a/driver/scsi_driver_extensions.h
+++ b/driver/scsi_driver_extensions.h
@@ -26,7 +26,7 @@ typedef struct _WNBD_EXTENSION {
     KEVENT                            GlobalDeviceRemovalEvent;
 } WNBD_EXTENSION, *PWNBD_EXTENSION;
 
-typedef struct _WNBD_SCSI_DEVICE
+typedef struct _WNBD_DISK_DEVICE
 {
     LIST_ENTRY                  ListEntry;
     PWNBD_EXTENSION             DeviceExtension;
@@ -67,7 +67,7 @@ typedef struct _WNBD_SCSI_DEVICE
     ULONG                       ReadPreallocatedBufferLength;
     PVOID                       WritePreallocatedBuffer;
     ULONG                       WritePreallocatedBufferLength;
-} WNBD_SCSI_DEVICE, *PWNBD_SCSI_DEVICE;
+} WNBD_DISK_DEVICE, *PWNBD_DISK_DEVICE;
 
 typedef struct _SRB_QUEUE_ELEMENT {
     LIST_ENTRY Link;

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -23,7 +23,7 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
     ASSERT(DeviceExtension);
 
     UCHAR SrbStatus = SRB_STATUS_NO_DEVICE;
-    PWNBD_SCSI_DEVICE Device;
+    PWNBD_DISK_DEVICE Device;
 
     if (SrbGetCdb(Srb)) {
         BYTE CdbValue = SrbGetCdb(Srb)->AsByte[0];
@@ -120,7 +120,7 @@ WnbdExecuteScsiFunction(PVOID DeviceExtension,
 
     NTSTATUS Status = STATUS_SUCCESS;
     UCHAR SrbStatus = SRB_STATUS_NO_DEVICE;
-    PWNBD_SCSI_DEVICE Device;
+    PWNBD_DISK_DEVICE Device;
     *Complete = TRUE;
 
     if (SrbGetCdb(Srb)) {

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -14,7 +14,7 @@
 #include "util.h"
 
 UCHAR
-WnbdReadCapacity(_In_ PWNBD_SCSI_DEVICE Device,
+WnbdReadCapacity(_In_ PWNBD_DISK_DEVICE Device,
                  _In_ PSCSI_REQUEST_BLOCK Srb,
                  _In_ PCDB Cdb,
                  _In_ UINT BlockSize,
@@ -161,7 +161,7 @@ WnbdSetVpdSerialNumber(_In_ PVOID Data,
 
 VOID
 WnbdSetVpdBlockLimits(_In_ PVOID Data,
-                      _In_ PWNBD_SCSI_DEVICE Device,
+                      _In_ PWNBD_DISK_DEVICE Device,
                       _In_ PSCSI_REQUEST_BLOCK Srb,
                       _In_ UINT32 MaximumTransferLength)
 {
@@ -199,7 +199,7 @@ WnbdSetVpdBlockLimits(_In_ PVOID Data,
 VOID
 WnbdSetVpdLogicalBlockProvisioning(
     _In_ PVOID Data,
-    _In_ PWNBD_SCSI_DEVICE Device,
+    _In_ PWNBD_DISK_DEVICE Device,
     _In_ PSCSI_REQUEST_BLOCK Srb)
 {
     WNBD_LOG_LOUD(": Enter");
@@ -226,7 +226,7 @@ WnbdSetVpdLogicalBlockProvisioning(
 VOID
 WnbdSetVpdBlockDeviceCharacteristics(
     _In_ PVOID Data,
-    _In_ PWNBD_SCSI_DEVICE Device,
+    _In_ PWNBD_DISK_DEVICE Device,
     _In_ PSCSI_REQUEST_BLOCK Srb)
 {
     WNBD_LOG_LOUD(": Enter");
@@ -252,7 +252,7 @@ WnbdProcessExtendedInquiry(_In_ PVOID Data,
                            _In_ ULONG Length,
                            _In_ PSCSI_REQUEST_BLOCK Srb,
                            _In_ PCDB Cdb,
-                           _In_ PWNBD_SCSI_DEVICE Device)
+                           _In_ PWNBD_DISK_DEVICE Device)
 {
     WNBD_LOG_LOUD(": Enter");
     ASSERT(Data);
@@ -313,7 +313,7 @@ Exit:
 }
 
 UCHAR
-WnbdInquiry(_In_ PWNBD_SCSI_DEVICE Device,
+WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
             _In_ PSCSI_REQUEST_BLOCK Srb,
             _In_ PCDB Cdb)
 {
@@ -439,7 +439,7 @@ Exit:
 }
 
 UCHAR
-WnbdModeSense(_In_ PWNBD_SCSI_DEVICE Device,
+WnbdModeSense(_In_ PWNBD_DISK_DEVICE Device,
               _In_ PSCSI_REQUEST_BLOCK Srb,
               _In_ PCDB Cdb)
 {
@@ -484,7 +484,7 @@ Exit:
 
 NTSTATUS
 WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
-                _In_ PWNBD_SCSI_DEVICE Device,
+                _In_ PWNBD_DISK_DEVICE Device,
                 _In_ PSCSI_REQUEST_BLOCK Srb,
                 _In_ UINT64 StartingLbn,
                 _In_ UINT64 DataLength,
@@ -522,7 +522,7 @@ Exit:
 
 NTSTATUS
 WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
-                  _In_ PWNBD_SCSI_DEVICE Device,
+                  _In_ PWNBD_DISK_DEVICE Device,
                   _In_ PSCSI_REQUEST_BLOCK Srb)
 {
     WNBD_LOG_LOUD(": Enter");
@@ -644,7 +644,7 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
 _Use_decl_annotations_
 NTSTATUS
 WnbdHandleSrbOperation(PWNBD_EXTENSION DeviceExtension,
-                       PWNBD_SCSI_DEVICE Device,
+                       PWNBD_DISK_DEVICE Device,
                        PSCSI_REQUEST_BLOCK Srb)
 {
     WNBD_LOG_LOUD(": Enter");

--- a/driver/scsi_operation.h
+++ b/driver/scsi_operation.h
@@ -12,6 +12,6 @@
 
 NTSTATUS
 WnbdHandleSrbOperation(_In_ PWNBD_EXTENSION DeviceExtension,
-                       _In_ PWNBD_SCSI_DEVICE ScsiDeviceExtension,
+                       _In_ PWNBD_DISK_DEVICE ScsiDeviceExtension,
                        _In_ PSCSI_REQUEST_BLOCK Srb);
 #endif

--- a/driver/util.h
+++ b/driver/util.h
@@ -11,12 +11,12 @@
 #include "scsi_driver_extensions.h"
 
 VOID
-DrainDeviceQueue(_In_ PWNBD_SCSI_DEVICE Device,
+DrainDeviceQueue(_In_ PWNBD_DISK_DEVICE Device,
                  _In_ BOOLEAN SubmittedRequests);
 VOID
-AbortSubmittedRequests(_In_ PWNBD_SCSI_DEVICE Device);
+AbortSubmittedRequests(_In_ PWNBD_DISK_DEVICE Device);
 VOID
-CompleteRequest(_In_ PWNBD_SCSI_DEVICE Device,
+CompleteRequest(_In_ PWNBD_DISK_DEVICE Device,
                 _In_ PSRB_QUEUE_ELEMENT Element,
                 _In_ BOOLEAN FreeElement);
 
@@ -26,36 +26,36 @@ WnbdCleanupAllDevices(_In_ PWNBD_EXTENSION DeviceExtension);
 // Increments the device rundown protection reference count, preventing
 // it from being cleaned up.
 BOOLEAN
-WnbdAcquireDevice(_In_ PWNBD_SCSI_DEVICE Device);
+WnbdAcquireDevice(_In_ PWNBD_DISK_DEVICE Device);
 // Decrements the reference count. All "WnbdAcquireDevice" calls must
 // be paired with a "WnbdReleaseDevice" call.
 VOID
-WnbdReleaseDevice(_In_ PWNBD_SCSI_DEVICE Device);
+WnbdReleaseDevice(_In_ PWNBD_DISK_DEVICE Device);
 // Signals the device cleanup thread, setting the "*TerminateDevice" flags
 // to avoid further processing.
 VOID
-WnbdDisconnectAsync(PWNBD_SCSI_DEVICE Device);
+WnbdDisconnectAsync(PWNBD_DISK_DEVICE Device);
 // The specified device must be acquired. It will be released by
 // WnbdDisconnectSync.
 VOID
-WnbdDisconnectSync(_In_ PWNBD_SCSI_DEVICE Device);
+WnbdDisconnectSync(_In_ PWNBD_DISK_DEVICE Device);
 
 // Device returned by WnbdFindDevice* functions must be subsequently
 // relased using WnbdReleaseDevice, if "Acquire" is set.
 // Unacquired device pointers must not be dereferenced.
-PWNBD_SCSI_DEVICE
+PWNBD_DISK_DEVICE
 WnbdFindDeviceByAddr(
     _In_ PWNBD_EXTENSION DeviceExtension,
     _In_ UCHAR PathId,
     _In_ UCHAR TargetId,
     _In_ UCHAR Lun,
     _In_ BOOLEAN Acquire);
-PWNBD_SCSI_DEVICE
+PWNBD_DISK_DEVICE
 WnbdFindDeviceByConnId(
     _In_ PWNBD_EXTENSION DeviceExtension,
     _In_ UINT64 ConnectionId,
     _In_ BOOLEAN Acquire);
-PWNBD_SCSI_DEVICE
+PWNBD_DISK_DEVICE
 WnbdFindDeviceByInstanceName(
     _In_ PWNBD_EXTENSION DeviceExtension,
     _In_ PCHAR InstanceName,
@@ -64,11 +64,11 @@ WnbdFindDeviceByInstanceName(
 BOOLEAN
 IsReadSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
 
-VOID DisconnectSocket(_In_ PWNBD_SCSI_DEVICE Device);
-VOID CloseSocket(_In_ PWNBD_SCSI_DEVICE Device);
+VOID DisconnectSocket(_In_ PWNBD_DISK_DEVICE Device);
+VOID CloseSocket(_In_ PWNBD_DISK_DEVICE Device);
 int ScsiOpToNbdReqType(_In_ int ScsiOp);
 BOOLEAN ValidateScsiRequest(
-    _In_ PWNBD_SCSI_DEVICE Device,
+    _In_ PWNBD_DISK_DEVICE Device,
     _In_ PSRB_QUEUE_ELEMENT Element);
 
 #define LIST_FORALL_SAFE(_headPtr, _itemPtr, _nextPtr)                \

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -68,7 +68,7 @@ NTSTATUS LockUsermodeBuffer(
 
 NTSTATUS WnbdDispatchRequest(
     PIRP Irp,
-    PWNBD_SCSI_DEVICE Device,
+    PWNBD_DISK_DEVICE Device,
     PWNBD_IOCTL_FETCH_REQ_COMMAND Command)
 {
     PVOID Buffer;
@@ -220,7 +220,7 @@ Exit:
 
 NTSTATUS WnbdHandleResponse(
     PIRP Irp,
-    PWNBD_SCSI_DEVICE Device,
+    PWNBD_DISK_DEVICE Device,
     PWNBD_IOCTL_SEND_RSP_COMMAND Command)
 {
     PSRB_QUEUE_ELEMENT Element = NULL;

--- a/driver/wnbd_dispatch.h
+++ b/driver/wnbd_dispatch.h
@@ -11,12 +11,12 @@ NTSTATUS LockUsermodeBuffer(
 
 NTSTATUS WnbdDispatchRequest(
     PIRP Irp,
-    PWNBD_SCSI_DEVICE Device,
+    PWNBD_DISK_DEVICE Device,
     PWNBD_IOCTL_FETCH_REQ_COMMAND Command);
 
 NTSTATUS WnbdHandleResponse(
     PIRP Irp,
-    PWNBD_SCSI_DEVICE Device,
+    PWNBD_DISK_DEVICE Device,
     PWNBD_IOCTL_SEND_RSP_COMMAND Command);
 
 #endif // WNBD_DISPATCH_H

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -1,6 +1,7 @@
 #ifndef WNBD_SHARED_H
 #define WNBD_SHARED_H
 
+#include <windows.h>
 #include <cfgmgr32.h>
 
 #include "wnbd_ioctl.h"
@@ -69,7 +70,6 @@ typedef struct _WNBD_DEVICE
     PVOID Context;
     WNBD_PROPERTIES Properties;
     WNBD_CONNECTION_INFO ConnectionInfo;
-    WnbdLogLevel LogLevel;
     const WNBD_INTERFACE *Interface;
     BOOLEAN Stopping;
     BOOLEAN Stopped;
@@ -104,7 +104,6 @@ typedef VOID (*UnmapFunc)(
     PWNBD_UNMAP_DESCRIPTOR Descriptors,
     UINT32 Count);
 typedef VOID (*LogMessageFunc)(
-    PWNBD_DEVICE Device,
     WnbdLogLevel LogLevel,
     const char* Message,
     const char* FileName,
@@ -120,15 +119,13 @@ typedef struct _WNBD_INTERFACE
     WriteFunc Write;
     FlushFunc Flush;
     UnmapFunc Unmap;
-    LogMessageFunc LogMessage;
-    VOID* Reserved[14];
+    VOID* Reserved[15];
 } WNBD_INTERFACE, *PWNBD_INTERFACE;
 
 DWORD WnbdCreate(
     const PWNBD_PROPERTIES Properties,
     const PWNBD_INTERFACE Interface,
     PVOID Context,
-    WnbdLogLevel LogLevel,
     PWNBD_DEVICE* PDevice);
 // Remove the disk. The existing dispatchers will continue running until all
 // the driver IO requests are completed unless the "HardRemove" flag is set.
@@ -161,7 +158,11 @@ DWORD WnbdGetConnectionInfo(
     PWNBD_DEVICE Device,
     PWNBD_CONNECTION_INFO ConnectionInfo);
 
-DWORD WnbdRaiseLogLevel(USHORT LogLevel);
+// libwnbd logger
+VOID WnbdSetLogger(LogMessageFunc Logger);
+VOID WnbdSetLogLevel(WnbdLogLevel LogLevel);
+
+DWORD WnbdRaiseDrvLogLevel(USHORT LogLevel);
 
 // Get libwnbd version.
 DWORD WnbdGetLibVersion(PWNBD_VERSION Version);

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -150,6 +150,9 @@ DWORD WnbdShow(
 DWORD WnbdGetUserspaceStats(
     PWNBD_DISK Disk,
     PWNBD_USR_STATS Stats);
+DWORD WnbdGetUserContext(
+    PWNBD_DISK Disk,
+    PVOID* Context);
 // Driver counters
 DWORD WnbdGetDriverStats(
     const char* InstanceName,

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -324,6 +324,18 @@ DWORD WnbdGetUserspaceStats(
     return ERROR_SUCCESS;
 }
 
+DWORD WnbdGetUserContext(
+    PWNBD_DISK Disk,
+    PVOID* Context)
+{
+    if (!Disk) {
+        LogError("No device specified.");
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    *Context = Disk->Context;
+    return ERROR_SUCCESS;
+}
 
 DWORD WnbdGetDriverStats(
     const char* InstanceName,

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -24,9 +24,9 @@ EXPORTS
     WnbdGetDriverVersion
     WnbdGetLibVersion
 
-    WnbdOpenDevice
-    WnbdOpenDeviceEx
-    WnbdOpenCMDeviceInstance
+    WnbdOpenAdapter
+    WnbdOpenAdapterEx
+    WnbdOpenAdapterCMDeviceInstance
     WnbdIoctlPing
     WnbdIoctlCreate
     WnbdIoctlRemove

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -9,7 +9,9 @@ EXPORTS
     WnbdShow
     WnbdGetUserspaceStats
     WnbdGetDriverStats
-    WnbdRaiseLogLevel
+    WnbdSetLogger
+    WnbdSetLogLevel
+    WnbdRaiseDrvLogLevel
     WnbdSetSenseEx
     WnbdSetSense
     WnbdStartDispatcher

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -8,6 +8,7 @@ EXPORTS
     WnbdList
     WnbdShow
     WnbdGetUserspaceStats
+    WnbdGetUserContext
     WnbdGetDriverStats
     WnbdSetLogger
     WnbdSetLogLevel

--- a/libwnbd/libwnbd.vcxproj
+++ b/libwnbd/libwnbd.vcxproj
@@ -15,13 +15,17 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="wnbd_ioctl.c" />
     <ClCompile Include="libwnbd.cpp" />
+    <ClCompile Include="utils.cpp" />
+    <ClCompile Include="wnbd_ioctl.cpp" />
+    <ClCompile Include="wnbd_log.c" />
     <ClCompile Include="wnbd_wmi.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\wnbd.h" />
     <ClInclude Include="..\include\wnbd_ioctl.h" />
+    <ClInclude Include="utils.h" />
+    <ClInclude Include="wnbd_log.h" />
     <ClInclude Include="wnbd_wmi.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/libwnbd/libwnbd.vcxproj.filters
+++ b/libwnbd/libwnbd.vcxproj.filters
@@ -15,13 +15,19 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="wnbd_ioctl.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="wnbd_wmi.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="libwnbd.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wnbd_log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wnbd_ioctl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="utils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -33,6 +39,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\wnbd_ioctl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wnbd_log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libwnbd/utils.cpp
+++ b/libwnbd/utils.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include <codecvt>
+#include <locale>
+#include <string>
+#include <sstream>
+
+#include <windows.h>
+
+std::wstring to_wstring(const char* str)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
+    return strconverter.from_bytes(str);
+}
+
+std::string to_string(std::wstring wstr)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
+    return strconverter.to_bytes(wstr);
+}
+
+std::string win32_strerror(int err)
+{
+    LPSTR msg = NULL;
+    DWORD msg_len = ::FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        err,
+        0,
+        (LPSTR) &msg,
+        0,
+        NULL);
+    if (!msg_len) {
+        std::ostringstream msg_stream;
+        msg_stream << "Unknown error (" << err << ").";
+        return msg_stream.str();
+    }
+    std::string msg_s(msg);
+    ::LocalFree(msg);
+    return msg_s;
+}

--- a/libwnbd/utils.h
+++ b/libwnbd/utils.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string>
+
+std::wstring to_wstring(const char* str);
+std::string to_string(std::wstring wstr);
+std::string win32_strerror(int err);

--- a/libwnbd/wnbd_log.c
+++ b/libwnbd/wnbd_log.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include <stdio.h>
+
+#include "wnbd_log.h"
+#include "wnbd.h"
+
+VOID ConsoleLogger(
+    WnbdLogLevel LogLevel,
+    const char* Message,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName)
+{
+    fprintf(stderr, "libwnbd.dll!%s %s %s\n",
+            FunctionName, WnbdLogLevelToStr(LogLevel), Message);
+}
+
+static LogMessageFunc WnbdCurrLogger = ConsoleLogger;
+static WnbdLogLevel WnbdCurrLogLevel = WnbdLogLevelWarning;
+
+VOID LogMessage(WnbdLogLevel LogLevel,
+                const char* FileName, UINT32 Line, const char* FunctionName,
+                const char* Format, ...)
+{
+    LogMessageFunc CurrLogger = WnbdCurrLogger;
+    WnbdLogLevel CurrLogLevel = WnbdCurrLogLevel;
+
+    if (!CurrLogger || CurrLogLevel < LogLevel)
+        return;
+
+    va_list Args;
+    va_start(Args, Format);
+
+    size_t BufferLength = (size_t)_vscprintf(Format, Args) + 1;
+
+    // TODO: consider enforcing WNBD_LOG_MESSAGE_MAX_SIZE and using a fixed
+    // size buffer for performance reasons.
+    char* Buff = (char*) malloc(BufferLength);
+    if (!Buff)
+        return;
+
+    vsnprintf_s(Buff, BufferLength, BufferLength - 1, Format, Args);
+    va_end(Args);
+
+    CurrLogger(LogLevel, Buff, FileName, Line, FunctionName);
+
+    free(Buff);
+}
+
+VOID WnbdSetLogger(LogMessageFunc Logger)
+{
+    // Passing NULL should allow completely disabling the logger.
+    WnbdCurrLogger = Logger;
+}
+
+VOID WnbdSetLogLevel(WnbdLogLevel LogLevel)
+{
+    WnbdCurrLogLevel = LogLevel;
+}

--- a/libwnbd/wnbd_log.h
+++ b/libwnbd/wnbd_log.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include "wnbd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+VOID ConsoleLogger(
+    WnbdLogLevel LogLevel,
+    const char* Message,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName);
+
+VOID LogMessage(
+    WnbdLogLevel LogLevel,
+    const char* FileName,
+    UINT32 Line,
+    const char* FunctionName,
+    const char* Format, ...);
+
+#define LogCritical(Format, ...) \
+    LogMessage(WnbdLogLevelCritical, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogError(Format, ...) \
+    LogMessage(WnbdLogLevelError, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogWarning(Format, ...) \
+    LogMessage(WnbdLogLevelWarning, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogInfo(Format, ...) \
+    LogMessage(WnbdLogLevelInfo, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogDebug(Format, ...) \
+    LogMessage(WnbdLogLevelDebug, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+#define LogTrace(Format, ...) \
+    LogMessage(WnbdLogLevelTrace, \
+               __FILE__, __LINE__, __FUNCTION__, Format, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -83,7 +83,7 @@ DWORD CmdMap(
 
     WNBD_PROPERTIES Props = { 0 };
     HANDLE WnbdDriverHandle = INVALID_HANDLE_VALUE;
-    DWORD Status = WnbdOpenDevice(&WnbdDriverHandle);
+    DWORD Status = WnbdOpenAdapter(&WnbdDriverHandle);
     if (Status) {
         fprintf(
             stderr,
@@ -142,7 +142,7 @@ DWORD CmdStats(PCHAR InstanceName)
         return Status;
     }
 
-    printf("Device stats:\n");
+    printf("Disk stats:\n");
     printf("TotalReceivedIORequests: %llu\n", Stats.TotalReceivedIORequests);
     printf("TotalSubmittedIORequests: %llu\n", Stats.TotalSubmittedIORequests);
     printf("TotalReceivedIOReplies: %llu\n", Stats.TotalReceivedIOReplies);

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -29,7 +29,6 @@ int main(int argc, PCHAR argv[])
     // possible to avoid having issues because of uninitialized COM.
     HRESULT hres = WnbdCoInitializeBasic();
     if (FAILED(hres)) {
-        fprintf(stderr, "Failed to initialize COM. HRESULT: 0x%x.\n", hres);
         return HRESULT_CODE(hres);
     }
 


### PR DESCRIPTION
WNBD deals with two types of devices: SCSI adapters and SCSI disks.
We have functions such as WnbdOpenDevice or parameters such as
WNBD_DEVICE and it's hard to tell if those are adapters or disks
without being very familiar with the code.

This PR renames those functions and parameters in order to avoid
confusion.

Depends-On: https://github.com/cloudbase/wnbd/pull/24