### PR TITLE
driver: unmap/flush/FUA support

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -188,7 +188,10 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
         IoLocation->Parameters.DeviceCapabilities.Capabilities->Removable = 1;
         IoLocation->Parameters.DeviceCapabilities.Capabilities->EjectSupported = 1;
         break;
-    case IRP_MN_QUERY_REMOVE_DEVICE:
+    // We won't remove the device upon receiving IRP_MN_QUERY_REMOVE_DEVICE.
+    // The device removal might be vetoed by other parts of the storage stack,
+    // so we'd affect soft removals. The only downside is that if the remove
+    // gets vetoed, uninstalling the driver will require a reboot.
     case IRP_MN_REMOVE_DEVICE:
         {
             if (NULL == GlobalExt || !GlobalExt->DeviceCount) {

--- a/driver/nbd_dispatch.c
+++ b/driver/nbd_dispatch.c
@@ -104,7 +104,7 @@ WnbdProcessDeviceThreadRequests(_In_ PWNBD_DISK_DEVICE Device)
         switch (NbdReqType) {
         case NBD_CMD_WRITE:
         case NBD_CMD_TRIM:
-            if (Element->FUA && DevProps->Flags.UnmapSupported) {
+            if (Element->FUA && DevProps->Flags.FUASupported) {
                 NbdTransmissionFlags |= NBD_CMD_FLAG_FUA;
             }
         case NBD_CMD_READ:

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -213,8 +213,8 @@ WnbdSetVpdLogicalBlockProvisioning(
     if (Device->Properties.Flags.UnmapSupported)
     {
         LogicalBlockProvisioning->LBPU = 1;
-        // TODO: trim support doesn't imply thin provisioning, but there
-        // might be some assumptions. Check if we actually have to set this.
+        // Trim support doesn't imply thin provisioning, but there
+        // seem to be some assumptions.
         LogicalBlockProvisioning->ProvisioningType = PROVISIONING_TYPE_THIN;
     }
 
@@ -622,8 +622,6 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
             break;
         }
 
-        // TODO: can FUA be requested for UNMAP requests? NBD specs suggest
-        // that it can, storport.h and SCSI specs suggest otherwise.
         Status = WnbdPendElement(DeviceExtension, Device, Srb,
             BlockAddress * Device->Properties.BlockSize,
             (UINT64)BlockCount * Device->Properties.BlockSize,


### PR DESCRIPTION
driver: unmap/flush/FUA support

Those features are already supported by libwnbd and our nbd
client, we'll need to update our IO dispatcher to propagate
them.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>