### PR TITLE
Add new logging facilities and the ability to install and uninstall the driver via client

### DIFF
--- a/driver/debug.c
+++ b/driver/debug.c
@@ -40,4 +40,5 @@ WnbdLog(UINT32 Level,
     va_end(Args);
 
     DbgPrintEx(DPFLTR_SCSIMINIPORT_ID, Level, "%s:%lu %s\n", FuncName, Line, Buf);
+    WnbdWppTrace(Level, "%s:%lu %s\n", FuncName, Line, Buf);
 }

--- a/driver/debug.h
+++ b/driver/debug.h
@@ -16,6 +16,36 @@
 #define WNBD_LVL_INFO     DPFLTR_INFO_LEVEL
 #define WNBD_LVL_LOUD     (DPFLTR_INFO_LEVEL + 1)
 
+#ifdef WPPFILE
+#define WPPNAME                WnbdTraceGuid
+#define WPPGUID                E35EAF83, 0F07, 418A, 907C, 141CD200F252
+
+#define WPP_DEFINE_DEFAULT_BITS                                        \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                              \
+        WPP_DEFINE_BIT(TRACE_KDPRINT)                                  \
+        WPP_DEFINE_BIT(DEFAULT_TRACE_LEVEL)
+
+#define WPP_CONTROL_GUIDS                                              \
+        WPP_DEFINE_CONTROL_GUID(WPPNAME,(WPPGUID),                     \
+        WPP_DEFINE_DEFAULT_BITS )
+
+#define WPP_FLAGS_LEVEL_LOGGER(Flags, Level)                           \
+        WPP_LEVEL_LOGGER(Flags)
+
+#define WPP_FLAGS_LEVEL_ENABLED(Flags, Level)                          \
+        (WPP_LEVEL_ENABLED(Flags) &&                                   \
+        WPP_CONTROL(WPP_BIT_ ## Flags).Level >= Level)
+
+#define WPP_LEVEL_FLAGS_ENABLED(Level, Flags) \
+        (WPP_LEVEL_ENABLED(Flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= Level
+
+#include WPPFILE
+#else
+#define WPP_INIT_TRACING(DriverObject, RegistryPath)
+#define WPP_CLEANUP(DriverObject)
+#define WnbdWppTrace(...)
+#endif
+
 VOID
 WnbdLog(_In_ UINT32 Level,
         _In_ PCHAR FuncName,

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -29,6 +29,7 @@ NTSTATUS
 DriverEntry(PDRIVER_OBJECT DriverObject,
             PUNICODE_STRING RegistryPath)
 {
+    WPP_INIT_TRACING(DriverObject, RegistryPath);
     WNBD_LOG_LOUD(": Enter");
 
     /*
@@ -181,4 +182,5 @@ WnbdDriverUnload(PDRIVER_OBJECT DriverObject)
     }
 
     WNBD_LOG_LOUD(": Exit");
+    WPP_CLEANUP(DriverObject);
 }

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -12,6 +12,8 @@
 #include "userspace.h"
 #include "util.h"
 #include "options.h"
+#include "events.h"
+
 
 DRIVER_INITIALIZE DriverEntry;
 DRIVER_UNLOAD WnbdDriverUnload;
@@ -30,6 +32,12 @@ DriverEntry(PDRIVER_OBJECT DriverObject,
             PUNICODE_STRING RegistryPath)
 {
     WPP_INIT_TRACING(DriverObject, RegistryPath);
+
+    /*
+     * Register with ETW
+     */
+    EventRegisterWNBD();
+
     WNBD_LOG_LOUD(": Enter");
 
     /*
@@ -105,7 +113,6 @@ DriverEntry(PDRIVER_OBJECT DriverObject,
     GlobalExt = NULL;
 
     WNBD_LOG_LOUD(": Exit");
-
     /*
      * Report status in upper layers
      */
@@ -182,5 +189,9 @@ WnbdDriverUnload(PDRIVER_OBJECT DriverObject)
     }
 
     WNBD_LOG_LOUD(": Exit");
+    /*
+     *  Unregister from ETW
+     */
+    EventUnregisterWNBD();
     WPP_CLEANUP(DriverObject);
 }

--- a/driver/wnbd.rc
+++ b/driver/wnbd.rc
@@ -26,6 +26,10 @@
 #include "..\include\version.h"
 #include "..\include\vendor.h"
 
+LANGUAGE 9, 1
+1 11 "events_MSG00001.bin"
+1 WEVT_TEMPLATE "eventsTEMP.BIN"
+
 #define VER_INTERNALNAME_STR        "wnbd.sys"
 #define VER_ORIGINALFILENAME_STR    "wnbd.sys"
 

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -9,6 +9,7 @@
 
 #include <windows.h>
 #include <cfgmgr32.h>
+#include <SetupAPI.h>
 
 #include "wnbd_ioctl.h"
 
@@ -21,6 +22,9 @@ extern "C" {
 #define WNBD_LOG_MESSAGE_MAX_SIZE 4096
 #define WNBD_DEFAULT_RM_TIMEOUT_MS 30 * 1000
 #define WNBD_DEFAULT_RM_RETRY_INTERVAL_MS 2000
+
+#define WNBD_HARDWAREID "root\\wnbd"
+#define WNBD_HARDWAREID_LEN sizeof(WNBD_HARDWAREID)
 
 typedef enum
 {
@@ -272,6 +276,8 @@ DWORD WnbdOpenAdapter(PHANDLE Handle);
 DWORD WnbdOpenAdapterEx(PHANDLE Handle, PDEVINST CMDeviceInstance);
 DWORD WnbdOpenAdapterCMDeviceInstance(PDEVINST DeviceInstance);
 DWORD WnbdIoctlPing(HANDLE Adapter, LPOVERLAPPED Overlapped);
+DWORD WnbdUninstallDriver(PBOOL RebootRequired, BOOLEAN Fprce);
+DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired);
 
 // The "Overlapped" parameter used by WnbdIoctl* functions allows
 // asynchronous calls. If NULL, a valid overlapped structure is

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -28,10 +28,12 @@ EXPORTS
     WnbdSetDrvOpt
     WnbdResetDrvOpt
     WnbdListDrvOpt
-
+    WnbdInstallDriver
+    WnbdUninstallDriver
     WnbdOpenAdapter
     WnbdOpenAdapterEx
     WnbdOpenAdapterCMDeviceInstance
+
     WnbdIoctlPing
     WnbdIoctlCreate
     WnbdIoctlRemove

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -8,15 +8,20 @@
 #include <windef.h>
 #include <winioctl.h>
 #include <winioctl.h>
+#include <newdev.h>
 #include <ntddscsi.h>
+#include "Shlwapi.h"
 #include <setupapi.h>
 #include <string.h>
+#include <infstr.h>
 
 #include "wnbd.h"
 #include "wnbd_log.h"
 #include "utils.h"
 
 #pragma comment(lib, "Setupapi.lib")
+#pragma comment(lib, "Newdev.lib")
+#pragma comment(lib, "Shlwapi.lib")
 
 #define STRING_OVERFLOWS(Str, MaxLen) (strlen(Str + 1) > MaxLen)
 
@@ -136,6 +141,367 @@ DWORD WnbdOpenAdapterCMDeviceInstance(PDEVINST DeviceInstance)
     if (!Status) {
         CloseHandle(&Handle);
     }
+    return Status;
+}
+
+DWORD RemoveWnbdInf(_In_ LPCTSTR InfName)
+{
+    DWORD Status = 0;
+    HINF HandleInf = INVALID_HANDLE_VALUE;
+    TCHAR InfData[MAX_INF_STRING_LENGTH];
+    UINT ErrorLine;
+    INFCONTEXT Context;
+    BOOLEAN Found = FALSE;
+
+    HandleInf = SetupOpenInfFile(InfName, NULL, INF_STYLE_WIN4, &ErrorLine);
+    if (HandleInf == INVALID_HANDLE_VALUE) {
+        Status = GetLastError();
+        LogError("SetupOpenInfFile failed with "
+            "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        goto failed;
+    }
+    if (!SetupFindFirstLine(HandleInf, INFSTR_SECT_VERSION, INFSTR_KEY_CATALOGFILE, &Context)) {
+        Status = GetLastError();
+        LogError("SetupFindFirstLine failed with "
+            "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        goto failed;
+    }
+    if (!SetupGetStringField(&Context, 1, InfData, ARRAYSIZE(InfData), NULL)) {
+        Status = GetLastError();
+        LogError("SetupGetStringField failed with "
+            "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        goto failed;
+    }
+
+    /* Match the OEM inf file based on the catalog string wnbd.cat */
+    if (!wcscmp(InfData, L"wnbd.cat")) {
+        std::wstring SearchString(InfName);
+        if (!SetupUninstallOEMInf(
+            SearchString.substr(SearchString.find_last_of(L"\\") + 1).c_str(), SUOI_FORCEDELETE, 0)) {
+            Status = GetLastError();
+            LogError("SetupUninstallOEMInfA failed with "
+                "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        }
+    }
+
+failed:
+    if (HandleInf != INVALID_HANDLE_VALUE) {
+        SetupCloseInfFile(HandleInf);
+    }
+
+    return Status;
+}
+
+/* Cycle through all OEM inf files and try a best effort mode to remove all
+ * files which include the string wnbd.cat */
+VOID CleanDrivers()
+{
+    DWORD Status = 0;
+    TCHAR OemName[MAX_PATH];
+    HANDLE DirHandle = INVALID_HANDLE_VALUE;
+    WIN32_FIND_DATA OemFindData;
+
+    if (!GetWindowsDirectory(OemName, ARRAYSIZE(OemName))) {
+        Status = GetLastError();
+        LogError("GetWindowsDirectory failed with "
+            "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        return;
+    }
+    if (wcscat_s(OemName, ARRAYSIZE(OemName), L"\\INF\\OEM*.INF")) {
+        LogError("wcscat_s failed");
+        return;
+    }
+    DirHandle = FindFirstFile(OemName, &OemFindData);
+    if (DirHandle == INVALID_HANDLE_VALUE) {
+        /* No OEM files */
+        return;
+    }
+
+    do {
+        Status = RemoveWnbdInf(OemFindData.cFileName);
+        if (Status) {
+            LogError("Failed while trying to remove OEM file: %ls",
+                OemFindData.cFileName);
+        }
+    } while (FindNextFile(DirHandle, &OemFindData));
+
+    FindClose(DirHandle);
+
+    return;
+}
+
+DWORD RemoveWnbdDevice(HDEVINFO AdapterDevHandle, PSP_DEVINFO_DATA DevInfoData, PBOOL RebootRequired)
+{
+    SP_DRVINFO_DETAIL_DATA_A DrvDetailData = { 0 };
+    DrvDetailData.cbSize = sizeof DrvDetailData;
+    DWORD Status = ERROR_SUCCESS;
+
+    /* Queue the device for removal before trying to remove the OEM information file */
+    if (!DiUninstallDevice(0, AdapterDevHandle, DevInfoData, 0, RebootRequired)) {
+        Status = GetLastError();
+        LogError(
+            "Could not remove driver. "
+            "Error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+    }
+
+    return Status;
+}
+
+// We assume we are using a single WNBD adapter per host
+static DWORD FindWnbdAdapterDevice(HDEVINFO* AdapterDevHandle, SP_DEVINFO_DATA* DevInfoData)
+{
+    CHAR TempBuf[2048];
+    memset(TempBuf, 0, sizeof(TempBuf));
+    BOOL Found = FALSE;
+    DWORD Status = ERROR_FILE_NOT_FOUND;
+
+    *AdapterDevHandle = SetupDiGetClassDevsA(&WNBD_GUID, 0, 0, DIGCF_ALLCLASSES | DIGCF_PRESENT);
+    if (INVALID_HANDLE_VALUE == *AdapterDevHandle) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiGetClassDevs failed. "
+            "Error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    for (DWORD I = 0; !Found && SetupDiEnumDeviceInfo(*AdapterDevHandle, I, DevInfoData); I++)
+    {
+        if (!SetupDiGetDeviceRegistryPropertyA(*AdapterDevHandle, DevInfoData, SPDRP_HARDWAREID, 0,
+            (PBYTE)TempBuf, sizeof(TempBuf) - 1, 0)) {
+            continue;
+        }
+
+        if (strstr(TempBuf, WNBD_HARDWAREID) != NULL) {
+            Found = TRUE;
+            break;
+        }
+    }
+
+    if (!Found) {
+        Status = GetLastError();
+        if (ERROR_NO_MORE_ITEMS != Status) {
+            LogError(
+                "Failed to locate device with hardware id: %s. Error: %d. Error message: %s",
+                WNBD_HARDWAREID, Status, win32_strerror(Status).c_str());
+        }
+        return Status;
+    }
+
+    return ERROR_SUCCESS;
+}
+
+DWORD RemoveAllDevices(BOOLEAN Force)
+{
+    DWORD BufferSize = 0;
+    DWORD Status = 0;
+    PWNBD_CONNECTION_LIST ConnList = NULL;
+
+    WNBD_OPTION_VALUE OptValue = { WnbdOptBool };
+    /* Disallow new mappings so we can remove all current mappings */
+    OptValue.Data.AsBool = FALSE;
+    Status = WnbdSetDrvOpt("NewMappingsAllowed", &OptValue, FALSE);
+    if (Status) {
+        goto exit;
+    }
+
+    Status = WnbdList(ConnList, &BufferSize);
+    if (!BufferSize) {
+        goto exit;
+    }
+    ConnList = (PWNBD_CONNECTION_LIST)calloc(1, BufferSize);
+    if (NULL == ConnList) {
+        Status = ERROR_NOT_ENOUGH_MEMORY;
+        LogError(
+            "Failed to allocate %d bytes.", BufferSize);
+        goto exit;
+    }
+    Status = WnbdList(ConnList, &BufferSize);
+    if (Status) {
+        goto exit;
+    }
+    CHAR* InstanceName;
+    for (ULONG index = 0; index < ConnList->Count; index++) {
+        InstanceName = ConnList->Connections[index].Properties.InstanceName;
+        WNBD_REMOVE_OPTIONS RemoveOptions = { 0 };
+        RemoveOptions.Flags.HardRemoveFallback = TRUE;
+        RemoveOptions.SoftRemoveTimeoutMs = 30 * 1000;
+        RemoveOptions.SoftRemoveRetryIntervalMs = 1 * 1000;
+        RemoveOptions.Flags.HardRemove = Force;
+        Status = WnbdRemoveEx(InstanceName, &RemoveOptions);
+        if (Status) {
+            goto exit;
+        }
+    }
+
+exit:
+    if (ConnList) {
+        free(ConnList);
+    }
+    return Status;
+}
+
+DWORD WnbdUninstallDriver(PBOOL RebootRequired, BOOLEAN Force)
+{
+    DWORD Status = ERROR_SUCCESS;
+    HDEVINFO AdapterDevHandle = INVALID_HANDLE_VALUE;
+    SP_DEVINFO_DATA DevInfoData;
+    DevInfoData.cbSize = sizeof DevInfoData;
+
+    PWNBD_CONNECTION_LIST ConnList = NULL;
+    Status = RemoveAllDevices(Force);
+    if (Status) {
+        goto exit;
+    }
+
+    while (Status == ERROR_SUCCESS) {
+        Status = FindWnbdAdapterDevice(&AdapterDevHandle, &DevInfoData);
+        if (ERROR_SUCCESS != Status) {
+            goto exit;
+        }
+
+        Status = RemoveWnbdDevice(AdapterDevHandle, &DevInfoData, RebootRequired);
+
+        if (INVALID_HANDLE_VALUE != AdapterDevHandle) {
+            if (!SetupDiDestroyDeviceInfoList(AdapterDevHandle)) {
+                Status = GetLastError();
+                LogError("SetupDiDestroyDeviceInfoList failed with "
+                    "error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+            }
+        }
+
+        if (ERROR_SUCCESS != Status) {
+            LogError(
+                "Error: %d. Error message: %s", Status, win32_strerror(Status).c_str());
+        }
+    }
+
+exit:
+    CleanDrivers();
+    return Status;
+}
+
+DWORD CreateWnbdAdapter(CHAR* ClassName, SP_DEVINFO_DATA* DevInfoData, HDEVINFO* AdapterDevHandle)
+{
+    DWORD Status = 0;
+
+    if (INVALID_HANDLE_VALUE == (*AdapterDevHandle = SetupDiCreateDeviceInfoList(&WNBD_GUID, 0))) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiCreateDeviceInfoList failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    if (!SetupDiCreateDeviceInfoA(*AdapterDevHandle, ClassName, &WNBD_GUID, 0, 0, DICD_GENERATE_ID, DevInfoData)) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiCreateDeviceInfoA failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    if (!SetupDiSetDeviceRegistryPropertyA(*AdapterDevHandle, DevInfoData,
+        SPDRP_HARDWAREID, (PBYTE)WNBD_HARDWAREID, WNBD_HARDWAREID_LEN)) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiSetDeviceRegistryPropertyA failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    return Status;
+}
+
+DWORD InstallDriver(CHAR* FileNameBuf, HDEVINFO* AdapterDevHandle, PBOOL RebootRequired)
+{
+    GUID ClassGuid = { 0 };
+    CHAR ClassName[MAX_CLASS_NAME_LEN];
+    SP_DEVINFO_DATA DevInfoData;
+    DevInfoData.cbSize = sizeof(DevInfoData);
+    SP_DEVINSTALL_PARAMS_A InstallParams;
+    DWORD Status = 0;
+
+    if (!SetupDiGetINFClassA(FileNameBuf, &ClassGuid, ClassName, MAX_CLASS_NAME_LEN, 0)) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiGetINFClassA failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    if (CreateWnbdAdapter(ClassName, &DevInfoData, AdapterDevHandle)) {
+        return Status;
+    }
+
+    if (!SetupDiCallClassInstaller(DIF_REGISTERDEVICE, *AdapterDevHandle, &DevInfoData)) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiCallClassInstaller failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    InstallParams.cbSize = sizeof InstallParams;
+    if (!SetupDiGetDeviceInstallParamsA(*AdapterDevHandle, &DevInfoData, &InstallParams)) {
+        Status = GetLastError();
+        LogError(
+            "SetupDiGetDeviceInstallParamsA failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        return Status;
+    }
+
+    if (0 != (InstallParams.Flags & (DI_NEEDREBOOT | DI_NEEDRESTART))) {
+        *RebootRequired = TRUE;
+    }
+
+    return Status;
+}
+
+DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired)
+{
+    CHAR FullFileName[MAX_PATH];
+    DWORD Status = ERROR_SUCCESS;
+    HDEVINFO AdapterDevHandle = INVALID_HANDLE_VALUE;
+    SP_DEVINFO_DATA DevInfoData;
+    DevInfoData.cbSize = sizeof DevInfoData;
+
+    if (0 == GetFullPathNameA(FileName, MAX_PATH, FullFileName, 0)) {
+        Status = GetLastError();
+        LogError(
+            "Invalid file path: %s. Error: %d. Error message: %s",
+            FileName, Status, win32_strerror(Status).c_str());
+        goto exit;
+    }
+    if (FALSE == PathFileExistsA(FullFileName)) {
+        LogError("Could not find file: %s.", FullFileName);
+        Status = ERROR_FILE_NOT_FOUND;
+        goto exit;
+    }
+
+    // We assume that an installed driver has an WNBD device
+    if (ERROR_SUCCESS == FindWnbdAdapterDevice(&AdapterDevHandle, &DevInfoData)) {
+        LogError("Driver already installed");
+        Status = ERROR_DUPLICATE_FOUND;
+        goto exit;
+    }
+
+    Status = InstallDriver(FullFileName, &AdapterDevHandle, RebootRequired);
+    if (ERROR_SUCCESS != Status) {
+        LogError(
+            "Failed to install driver. Error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        goto exit;
+    }
+
+    if (!UpdateDriverForPlugAndPlayDevicesA(0, WNBD_HARDWAREID, FullFileName, 0, RebootRequired)) {
+        Status = GetLastError();
+        LogError(
+            "UpdateDriverForPlugAndPlayDevicesA failed with error: %d. Error message: %s",
+            Status, win32_strerror(Status).c_str());
+        goto exit;
+    }
+
+exit:
     return Status;
 }
 

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -79,6 +79,11 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WppEnabled>true</WppEnabled>
+      <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
+      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WppTraceFunction>WnbdWppTrace{FLAGS=MYDRIVER_ALL_INFO}(LEVEL,MSG,...)</WppTraceFunction>
+      <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
     </ClCompile>
     <Link />
     <Link />

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -163,9 +163,6 @@
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="wnbd.rc" />
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="..\driver\wnbd.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -47,6 +47,18 @@
     <DriverType>WDM</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemGroup Label="WrappedTaskItems">
+    <MessageCompile Include="wnbdevents.xml">
+      <GenerateKernelModeLoggingMacros>true</GenerateKernelModeLoggingMacros>
+      <HeaderFilePath>.\$(IntDir)</HeaderFilePath>
+      <GeneratedHeaderPath>true</GeneratedHeaderPath>
+      <WinmetaPath>"$(SDK_INC_PATH)\winmeta.xml"</WinmetaPath>
+      <RCFilePath>.\$(IntDir)</RCFilePath>
+      <GeneratedRCAndMessagesPath>true</GeneratedRCAndMessagesPath>
+      <GeneratedFilesBaseName>events</GeneratedFilesBaseName>
+      <UseBaseNameOfInput>true</UseBaseNameOfInput>
+    </MessageCompile>
+  </ItemGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -57,21 +69,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
@@ -148,6 +160,10 @@
     <ClInclude Include="..\driver\userspace.h" />
     <ClInclude Include="..\driver\util.h" />
     <ClInclude Include="..\driver\wnbd_dispatch.h" />
+    <ClInclude Include="resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="wnbd.rc" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\driver\wnbd.rc" />

--- a/vstudio/driver.vcxproj.filters
+++ b/vstudio/driver.vcxproj.filters
@@ -109,13 +109,11 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="wnbd.rc">
+    <ResourceCompile Include="..\driver\wnbd.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\driver\wnbd.rc">
-      <Filter>Resource Files</Filter>
-    </ResourceCompile>
+    <MessageCompile Include="wnbdevents.xml" />
   </ItemGroup>
 </Project>

--- a/vstudio/driver.vcxproj.filters
+++ b/vstudio/driver.vcxproj.filters
@@ -104,6 +104,14 @@
     <ClInclude Include="..\driver\options.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="wnbd.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\driver\wnbd.rc">

--- a/vstudio/reinstall.ps1
+++ b/vstudio/reinstall.ps1
@@ -5,6 +5,7 @@ $devconBin = "$scriptLocation\devcon.exe"
 $wnbdInf = "$scriptLocation\wnbd.inf"
 $wnbdCat = "$scriptLocation\wnbd.cat"
 $wnbdSys = "$scriptLocation\wnbd.sys"
+$wnbdevents = "$scriptLocation\wnbdevents.xml"
 
 $requiredFiles = @($devconBin, $wnbdInf, $wnbdCat, $wnbdSys)
 foreach ($path in $requiredFiles) {
@@ -14,8 +15,10 @@ foreach ($path in $requiredFiles) {
 }
 
 & $devconBin remove "root\wnbd"
+wevtutil um $wnbdevents
 
 pnputil.exe /enum-drivers | sls -Context 5 wnbd | findstr Published | `
     % {$_ -match "(oem\d+.inf)"; pnputil.exe /delete-driver $matches[0] /force }
 
 & $devconBin install $wnbdInf root\wnbd
+wevtutil im $wnbdevents

--- a/vstudio/resource.h
+++ b/vstudio/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by driver.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/vstudio/wnbd.rc
+++ b/vstudio/wnbd.rc
@@ -1,0 +1,62 @@
+// Microsoft Visual C++ generated resource script.
+//
+
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE 9, 1
+1 11 "events_MSG00001.bin"
+1 WEVT_TEMPLATE "eventsTEMP.BIN"
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE  
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE  
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/vstudio/wnbdevents.xml
+++ b/vstudio/wnbdevents.xml
@@ -1,0 +1,72 @@
+﻿<?xml version='1.0' encoding='utf-8' standalone='yes'?>
+<instrumentationManifest
+    xmlns="http://schemas.microsoft.com/win/2004/08/events"
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.microsoft.com/win/2004/08/events eventman.xsd">
+    <instrumentation>
+        <events>
+            <provider
+                guid="{FFACC4E7-C115-4FE2-9D3C-80FAE73BAB91}"
+                messageFileName="%WINDIR%\System32\drivers\wnbd.sys"
+                name="WNBD"
+                resourceFileName="%WINDIR%\System32\drivers\wnbd.sys"
+                symbol="WNBD">
+                <channels>
+                    <importChannel
+                        chid="SYSTEM"
+                        name="System"/>
+                </channels>
+                <templates>
+                    <template tid="tid_load_template">
+                        <data name="FunctionName"
+                              inType="win:AnsiString"
+                              outType="xs:string"/>
+                        <data name="LineNumber"
+                              inType="win:UInt32"
+                              outType="xs:unsignedInt"/>
+                        <data name="Message"
+                              inType="win:AnsiString"
+                              outType="xs:string"/>
+                    </template>
+                </templates>
+                <events>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Error"
+                        message="$(string.ErrorEvent.EventMessage)"
+                        opcode="win:Info"
+                        symbol="ErrorEvent"
+                        template="tid_load_template"
+                        value="1"/>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Warning"
+                        message="$(string.WarningEvent.EventMessage)"
+                        opcode="win:Info"
+                        symbol="WarningEvent"
+                        template="tid_load_template"
+                        value="2"/>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Informational"
+                        message="$(string.InformationalEvent.EventMessage)"
+                        opcode="win:Start"
+                        symbol="InformationalEvent"
+                        template="tid_load_template"
+                        value="3"/>
+                </events>
+            </provider>
+        </events>
+    </instrumentation>
+    <localization xmlns="http://schemas.microsoft.com/win/2004/08/events">
+        <resources culture="en-US">
+            <stringTable>
+                <string id="ErrorEvent.EventMessage" value="%1:%2 %3"/>
+                <string id="WarningEvent.EventMessage" value="%1:%2 %3"/>
+                <string id="InformationalEvent.EventMessage" value="%1:%2 %3"/>
+            </stringTable>
+        </resources>
+    </localization>
+</instrumentationManifest>

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -316,6 +316,32 @@ DWORD execute_reset_opt(const po::variables_map& vm)
         safe_get_param<bool>(vm, "persistent"));
 }
 
+DWORD execute_install(const po::variables_map& vm)
+{
+    return CmdInstall(
+        safe_get_param<string>(vm, "filename").c_str());
+}
+
+void get_filename_args(
+    po::positional_options_description& positonal_opts,
+    po::options_description& named_opts)
+{
+    positonal_opts.add("filename", 1);
+    named_opts.add_options()
+        ("filename", po::value<string>()->required(), "Absolute or relative path to"
+                                                      "the OEM driver information (wnbd.inf)");
+}
+
+DWORD execute_cleanup(const po::variables_map& vm)
+{
+    return CmdUninstall(FALSE);
+}
+
+DWORD execute_force_cleanup(const po::variables_map& vm)
+{
+    return CmdUninstall(TRUE);
+}
+
 Client::Command commands[] = {
     Client::Command(
         "version", {"-v"}, "Get the client, library and driver version.",
@@ -352,4 +378,15 @@ Client::Command commands[] = {
     Client::Command(
         "reset-opt", {}, "Reset driver option.",
         execute_reset_opt, get_reset_opt_args),
+    Client::Command(
+        "install-driver", {}, "Install WNBD driver and create its adapter",
+        execute_install, get_filename_args),
+    Client::Command(
+        "cleanup", {}, "Remove all disk mapping with a SOFT disconnect option"
+                       " and tries to uninstall all installed WNBD drivers.",
+        execute_cleanup),
+    Client::Command(
+        "force-cleanup", {}, "Remove all disk mapping with a HARD disconnect option"
+                             " and tries to uninstall all installed WNBD drivers.",
+        execute_force_cleanup),
 };

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -412,3 +412,29 @@ CmdListOpt(BOOLEAN Persistent)
     free(OptList);
     return 0;
 }
+
+DWORD
+CmdUninstall(BOOLEAN Force)
+{
+    BOOL RebootRequired = FALSE;
+    DWORD Status = WnbdUninstallDriver(&RebootRequired, Force);
+    if (RebootRequired) {
+        cerr << "Reboot required to complete the cleanup process"
+             << endl;
+    }
+
+    return Status;
+}
+
+DWORD
+CmdInstall(std::string FileName)
+{
+    BOOL RebootRequired = FALSE;
+    DWORD Status = WnbdInstallDriver(FileName.c_str(), &RebootRequired);
+    if (RebootRequired) {
+        cerr << "Reboot required to complete the installation"
+             << endl;
+    }
+
+    return Status;
+}

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -69,3 +69,9 @@ CmdResetOpt(std::string Name, BOOLEAN Persistent);
 
 DWORD
 CmdListOpt(BOOLEAN Persistent);
+
+DWORD
+CmdUninstall(BOOLEAN Force);
+
+DWORD
+CmdInstall(std::string FileName);


### PR DESCRIPTION
This PR adds two new logging facilities: one for WPP and one for ETW.

WPP tracing is enabled only on Debug builds for the moment and different tools
can be used used to capture its output.

ETW tracing is enabled on all builds.
To start a ETW trace session one can use:
`tracelog -start WNBDEventdrv -guid #FFACC4E7-C115-4FE2-9D3C-80FAE73BAB91 -f WNBDEventdrv.etl`

To stop:
`tracelog -stop WNBDEventdrv`

To display the trace use:
`tracerpt WNBDEventdrv.etl`

The `reinstall.ps1` script has been updated to install and remove our defined events.

Two new commands are added to `wnbd-client`: `install-driver <InfFileLocation>` and `uninstall-driver`.

The predefined hardware ID used for installation and lookup is `root\wnbd`.

When using the uninstall command please note that the OEM information is also marked for removal.