### PR TITLE
Always use an overlapped structure when calling DeviceIoControl

### DIFF
--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -191,6 +191,12 @@ DWORD WnbdSendResponse(
     PWNBD_IO_RESPONSE Response,
     PVOID DataBuffer,
     UINT32 DataBufferSize);
+DWORD WnbdSendResponseEx(
+    PWNBD_DISK Disk,
+    PWNBD_IO_RESPONSE Response,
+    PVOID DataBuffer,
+    UINT32 DataBufferSize,
+    LPOVERLAPPED Overlapped);
 
 /**
 * Retrieve a specific WNBD option.
@@ -254,52 +260,74 @@ DWORD WnbdListDrvOpt(
 DWORD WnbdOpenAdapter(PHANDLE Handle);
 DWORD WnbdOpenAdapterEx(PHANDLE Handle, PDEVINST CMDeviceInstance);
 DWORD WnbdOpenAdapterCMDeviceInstance(PDEVINST DeviceInstance);
-DWORD WnbdIoctlPing(HANDLE Adapter);
+DWORD WnbdIoctlPing(HANDLE Adapter, LPOVERLAPPED Overlapped);
 
+// The "Overlapped" parameter used by WnbdIoctl* functions allows
+// asynchronous calls. If NULL, a valid overlapped structure is
+// provided by libwnbd, also performing the wait on behalf of the
+// caller.
+//
+// NOTE: Overlapped structures should be re-used as much as possible,
+// avoiding the need of reinitializing the embedded event all the time,
+// especially for functions that are used in the IO path.
 DWORD WnbdIoctlCreate(
     HANDLE Adapter,
     PWNBD_PROPERTIES Properties,
     // The resulting connecting info.
-    PWNBD_CONNECTION_INFO ConnectionInfo);
+    PWNBD_CONNECTION_INFO ConnectionInfo,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlRemove(
     HANDLE Adapter,
     const char* InstanceName,
-    PWNBD_REMOVE_COMMAND_OPTIONS RemoveOptions);
+    PWNBD_REMOVE_COMMAND_OPTIONS RemoveOptions,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlList(
     HANDLE Adapter,
     PWNBD_CONNECTION_LIST ConnectionList,
     // Connection list buffer size.
-    PDWORD BufferSize);
+    PDWORD BufferSize,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlShow(
     HANDLE Adapter,
     const char* InstanceName,
-    PWNBD_CONNECTION_INFO ConnectionInfo);
+    PWNBD_CONNECTION_INFO ConnectionInfo,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlStats(
     HANDLE Adapter,
     const char* InstanceName,
-    PWNBD_DRV_STATS Stats);
+    PWNBD_DRV_STATS Stats,
+    LPOVERLAPPED Overlapped);
 // Reload the persistent settings provided through registry keys.
-DWORD WnbdIoctlReloadConfig(HANDLE Adapter);
-DWORD WnbdIoctlVersion(HANDLE Adapter, PWNBD_VERSION Version);
+DWORD WnbdIoctlReloadConfig(
+    HANDLE Adapter,
+    LPOVERLAPPED Overlapped);
+DWORD WnbdIoctlVersion(
+    HANDLE Adapter,
+    PWNBD_VERSION Version,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlGetDrvOpt(
     HANDLE Adapter,
     const char* Name,
     PWNBD_OPTION_VALUE Value,
-    BOOLEAN Persistent);
+    BOOLEAN Persistent,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlSetDrvOpt(
     HANDLE Adapter,
     const char* Name,
     PWNBD_OPTION_VALUE Value,
-    BOOLEAN Persistent);
+    BOOLEAN Persistent,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlResetDrvOpt(
     HANDLE Adapter,
     const char* Name,
-    BOOLEAN Persistent);
+    BOOLEAN Persistent,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlListDrvOpt(
     HANDLE Adapter,
     PWNBD_OPTION_LIST OptionList,
     PDWORD BufferSize,
-    BOOLEAN Persistent);
+    BOOLEAN Persistent,
+    LPOVERLAPPED Overlapped);
 
 // The connection id should be handled carefully in order to avoid delayed replies
 // from being submitted to other disks after being remapped.
@@ -308,13 +336,15 @@ DWORD WnbdIoctlFetchRequest(
     WNBD_CONNECTION_ID ConnectionId,
     PWNBD_IO_REQUEST Request,
     PVOID DataBuffer,
-    UINT32 DataBufferSize);
+    UINT32 DataBufferSize,
+    LPOVERLAPPED Overlapped);
 DWORD WnbdIoctlSendResponse(
     HANDLE Adapter,
     WNBD_CONNECTION_ID ConnectionId,
     PWNBD_IO_RESPONSE Response,
     PVOID DataBuffer,
-    UINT32 DataBufferSize);
+    UINT32 DataBufferSize,
+    LPOVERLAPPED Overlapped);
 
 HRESULT WnbdCoInitializeBasic();
 // Requires COM. For convenience, WnbdCoInitializeBasic may be used.

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -18,6 +18,7 @@ EXPORTS
     WnbdStopDispatcher
     WnbdWaitDispatcher
     WnbdSendResponse
+    WnbdSendResponseEx
     WnbdCoInitializeBasic
     WnbdGetDiskNumberBySerialNumber
     WnbdGetConnectionInfo

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -145,7 +145,7 @@ DWORD CmdMap(
     Props.BlockCount = BlockSize ? DiskSize / BlockSize : 0;
 
     WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
-    Status = WnbdIoctlCreate(WnbdDriverHandle, &Props, &ConnectionInfo);
+    Status = WnbdIoctlCreate(WnbdDriverHandle, &Props, &ConnectionInfo, NULL);
 
     CloseHandle(WnbdDriverHandle);
     return Status;


### PR DESCRIPTION
This change fixes deadlocks occurring when communicating with the
WNBD driver using DeviceIoControl[1][2].

We're setting FILE_FLAG_OVERLAPPED when opening the WNBD device
in order to be able to submit multiple requests simultaneously.
The Windows docs state that in this case, an OVERLAPED structure
must be passed to functions such as ReadFile or WriteFile without
explicitly mentioning DeviceIoControl.

Apparently DeviceIoControl can hang if we don't pass an overlapped
structure, especially when having a high number of concurrent
requests. This is likely related to the event wait involved.

We're going to update the libwnbd *Ioctl* functions, adding an
optional LPOVERLAPPED argument. When not provided by the caller,
we're initalizing an internal OVERLAPED structure and wait for
the operation on the behalf of the caller, mimicking the Windows
behavior.

We're trying to re-use overlapped structures and events as much
as possible, especially in the IO path. The IO dispatch loop
will reuse the same events but we can't do much about
"WnbdSendResponse" since that will be called by libwnbd consumers
from arbitrary threads. We're adding "WnbdSendResponseEx" though,
letting the caller provide an overlapped structure.

Another advantage of adding overlapped parameters is that we allow
libwnbd consumers to perform any *Ioctl* call asynchronously.

[1] profiler counters: http://paste.openstack.org/raw/797772/
[2] wnbd / ceph counters: http://paste.openstack.org/raw/799072/

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>