### PR TITLE
wnbd-client: use named arguments and improve help strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ tags
 /vstudio/x64/
 /vstudio/sdv/
 /vstudiox64/
+/vstudio/deps
 
 include/version.h

--- a/README.md
+++ b/README.md
@@ -150,24 +150,8 @@ The following samples describe configuring a Linux NBD server and connecting to 
 Please check [this page](https://github.com/NetworkBlockDevice/nbd#using-nbd) for more details
 about using NBD.
 
-### ``wnbd-client`` Syntax
-
-```PowerShell
-wnbd-client.exe -h
-```
-```
-Syntax:
-wnbd-client version
-wnbd-client map  <InstanceName> <HostName> <PortName> <ExportName> [<SkipNBDNegotiation> <ReadOnly> <DiskSize> <BlockSize>]
-wnbd-client unmap <InstanceName> [HardRemove]
-wnbd-client list
-wnbd-client stats <InstanceName>
-wnbd-client get-opt <OptionName> [Persistent]
-wnbd-client set-opt <OptionName> <OptionValue> [Persistent]
-wnbd-client reset-opt <OptionName> [Persistent]
-wnbd-client list-opt [Persistent]
-```
-
+Use ``wnbd-client help [<command-name>]`` to get the full list of commands as well as the
+available options.
 
 ### NBD server configuration
 

--- a/get_dependencies.ps1
+++ b/get_dependencies.ps1
@@ -1,0 +1,43 @@
+Param(
+  [switch]$Clean
+)
+
+$scriptLocation = [System.IO.Path]::GetDirectoryName(
+    $myInvocation.MyCommand.Definition)
+$ErrorActionPreference = "Stop"
+
+$nugetUrl = "https://dist.nuget.org/win-x86-commandline/v4.5.1/nuget.exe"
+
+$depsDir = "$scriptLocation\vstudio\deps"
+$nugetPath = "$depsDir\nuget.exe"
+$depsConfig = "$scriptLocation\packages.config"
+$completeFlag = "$depsDir\complete"
+
+function safe_exec($cmd) {
+    cmd /c "$cmd 2>&1"
+    $exitCode = $LASTEXITCODE
+    if ($exitCode) {
+        throw "Command failed: $cmd. Exit code: $exitCode"
+    }
+}
+
+if ($Clean -and (test-path $depsDir)) {
+    rm -recurse -force $depsDir
+    Write-Host "Cleaning up dependencies: $depsDir"
+}
+
+mkdir -force $depsDir
+if (!(test-path $nugetPath)) {
+    Write-Host "Fetching nuget from $nugetUrl."
+    Invoke-WebRequest $nugetUrl -OutFile $nugetPath
+}
+
+if (!(test-path $completeFlag)) {
+    Write-Host "Retrieving dependencies."
+    safe_exec "$nugetPath install $depsConfig -OutputDirectory `"$depsDir`""
+    sc $completeFlag "Finished retrieving dependencies."
+}
+else {
+    write-host "Nuget dependencies already fetched."
+}
+

--- a/libwnbd/libwnbd.vcxproj
+++ b/libwnbd/libwnbd.vcxproj
@@ -99,9 +99,6 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -124,9 +121,6 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -149,9 +143,6 @@
       <ModuleDefinitionFile>libwnbd.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)\pdb\libwnbd\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_program_options-src" version="1.72.0.0" targetFramework="native" />
+</packages>

--- a/vstudio/build_deps.vcxproj
+++ b/vstudio/build_deps.vcxproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This project handles build prerequisites, fetching dependencies and generating the
+     version header. It's provided merely as a convenience, avoiding the need of
+     explicitly invoking external scripts.
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Analyze|x64">
+      <Configuration>Analyze</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{4ee28b36-2083-4fba-88d7-fe60027b81bb}</ProjectGuid>
+    <RootNamespace>builddeps</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+
+  <Target Name="Build">
+    <Exec Command="powershell.exe -executionpolicy bypass -file &quot;$(SolutionDir)\generate_version_h.ps1&quot;" />
+    <Exec Command="powershell.exe -executionpolicy bypass -file &quot;$(SolutionDir)\..\get_dependencies.ps1&quot;" />
+    <PropertyGroup>
+      <MissingDepsError>Missing dependency: {0}. It was supposed to be retrieved using "get_dependencies.ps1".</MissingDepsError>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(MissingDepsError)', '$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" Text="$([System.String]::Format('$(MissingDepsError)', '$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets'))" />
+  </Target>
+</Project>

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -86,9 +86,6 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;$(DDK_LIB_PATH )libcntpr.lib;$(DDK_LIB_PATH )wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -98,9 +95,6 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -110,9 +104,6 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-    </PreBuildEvent>
     <PostBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -command $env:VCINSTALLDIR='$(VCInstallDir)'; cd $(SolutionDir); msbuild $(SolutionFileName) /p:Configuration=Release; msbuild $(ProjectFileName) /t:sdv /p:inputs='/check' /p:Configuration=Release /p:SolutionDir=$(SolutionDir); msbuild $(ProjectFileName) /p:Configuration=Release /P:RunCodeAnalysisOnce=True</Command>
     </PostBuildEvent>

--- a/vstudio/driver.vcxproj.user
+++ b/vstudio/driver.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/vstudio/reinstall.ps1
+++ b/vstudio/reinstall.ps1
@@ -6,28 +6,11 @@ $wnbdInf = "$scriptLocation\wnbd.inf"
 $wnbdCat = "$scriptLocation\wnbd.cat"
 $wnbdSys = "$scriptLocation\wnbd.sys"
 
-$status = Test-Path -Path $devconBin -PathType leaf
-
-if ($status -eq $false) {
-    Write-Host "Devcon utility not found in $scriptLocation"
-}
-
-$status = Test-Path -Path $wnbdInf -PathType leaf
-
-if ($status -eq $false) {
-    Write-Host "wnbd.inf not found in $scriptLocation"
-}
-
-$status = Test-Path -Path $wnbdCat -PathType leaf
-
-if ($status -eq $false) {
-    Write-Host "wnbd.cat not found in $scriptLocation"
-}
-
-$status = Test-Path -Path $wnbdSys -PathType leaf
-
-if ($status -eq $false) {
-    Write-Host "wnbd.sys not found in $scriptLocation"
+$requiredFiles = @($devconBin, $wnbdInf, $wnbdCat, $wnbdSys)
+foreach ($path in $requiredFiles) {
+    if (!(Test-Path -Path $path -PathType leaf)) {
+        Write-Warning "Could not find file: $path"
+    }
 }
 
 & $devconBin remove "root\wnbd"

--- a/vstudio/wnbd.sln
+++ b/vstudio/wnbd.sln
@@ -4,6 +4,7 @@ VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "driver", "driver.vcxproj", "{0091FAE6-479E-40CB-985E-1AC3FB633391}"
 	ProjectSection(ProjectDependencies) = postProject
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB} = {4EE28B36-2083-4FBA-88D7-FE60027B81BB}
 		{8C21EBB6-5127-4D50-A418-69771C8EC40E} = {8C21EBB6-5127-4D50-A418-69771C8EC40E}
 	EndProjectSection
 EndProject
@@ -12,9 +13,15 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wnbd-client", "..\wnbd-client\wnbd-client.vcxproj", "{A9A19AD0-D8F6-4D41-9B82-375370C408D7}"
 	ProjectSection(ProjectDependencies) = postProject
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA} = {15FFEE2F-F65A-47D1-8389-15E5ADD971CA}
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB} = {4EE28B36-2083-4FBA-88D7-FE60027B81BB}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libwnbd", "..\libwnbd\libwnbd.vcxproj", "{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB} = {4EE28B36-2083-4FBA-88D7-FE60027B81BB}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "build_deps", "build_deps.vcxproj", "{4EE28B36-2083-4FBA-88D7-FE60027B81BB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +58,12 @@ Global
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Debug|x64.Build.0 = Debug|x64
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Release|x64.ActiveCfg = Release|x64
 		{15FFEE2F-F65A-47D1-8389-15E5ADD971CA}.Release|x64.Build.0 = Release|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Analyze|x64.ActiveCfg = Analyze|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Analyze|x64.Build.0 = Analyze|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Debug|x64.ActiveCfg = Debug|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Debug|x64.Build.0 = Debug|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Release|x64.ActiveCfg = Release|x64
+		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "client.h"
+#include "cmd.h"
+#include "usage.h"
+#include "wnbd.h"
+#include "version.h"
+
+#include <boost/exception/diagnostic_information.hpp>
+
+#include <iostream>
+#include <iomanip>
+
+namespace po = boost::program_options;
+using namespace std;
+
+vector<Client::Command*> Client::commands;
+
+Client::Command* Client::get_command(string name)
+{
+    for (Client::Command *command : Client::commands) {
+        if (command->name == name)
+            return command;
+        for (auto alias: command->aliases) {
+            if (alias == name)
+                return command;
+        }
+    }
+
+    return nullptr;
+}
+
+// Make sure to pass the EXACT SAME type that was used when defining the option,
+// otherwise Boost will throw an exception.
+template <class T>
+T safe_get_param(const po::variables_map& vm, string name, T default_val = T())
+{
+    if (vm.count(name)) {
+        return vm[name].as<T>();
+    }
+    return default_val;
+}
+
+void Client::get_common_options(po::options_description &options)
+{
+    options.add_options()
+        ("debug", po::bool_switch(), "Enable debug logging.");
+}
+
+void handle_common_options(po::variables_map &vm)
+{
+    bool debug = safe_get_param<bool>(vm, "debug");
+
+    WnbdLogLevel log_level = debug ? WnbdLogLevelDebug : WnbdLogLevelInfo;
+    WnbdSetLogLevel(log_level);
+}
+
+DWORD Client::execute(int argc, const char** argv)
+{
+    vector<string> args;
+    args.insert(args.end(), argv + 1, argv + argc);
+
+    // The first must argument must be the command name.
+    if (args.size() == 0) {
+        args.push_back("help");
+    }
+    string command_name = args[0];
+
+    Client::Command* command = get_command(command_name);
+    if (!command) {
+        cerr << "Unknown command: " << command_name << endl << endl
+             << "See wnbd-client --help." << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+    // Remove the command from the list of arguments.
+    args.erase(args.begin());
+
+    try {
+        po::positional_options_description positional_opts;
+        po::options_description named_opts;
+
+        if (command->get_options) {
+            command->get_options(positional_opts, named_opts);
+        }
+        get_common_options(named_opts);
+
+        po::variables_map vm;
+        po::store(po::command_line_parser(args)
+            .options(named_opts)
+            .positional(positional_opts)
+            .run(), vm);
+        po::notify(vm);
+
+        handle_common_options(vm);
+        return command->execute(vm);
+    }
+    catch (po::required_option& e) {
+        cerr << "wnbd-client: " << e.what() << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+    catch (po::too_many_positional_options_error&) {
+        cerr << "wnbd-client: too many arguments" << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+    catch (po::error& e) {
+        cerr << "wnbd-client: " << e.what() << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+    catch (...) {
+        cerr << "wnbd-client: Caught unexpected exception." << endl << endl;
+        cerr << boost::current_exception_diagnostic_information() << endl;
+        return ERROR_INTERNAL_ERROR;
+    }
+}
+
+DWORD execute_version(const po::variables_map &vm)
+{
+    return CmdVersion();
+}
+
+DWORD execute_help(const po::variables_map &vm)
+{
+    if (vm.count("command-name")) {
+        string command_name = vm["command-name"].as<string>();
+        return print_command_help(command_name);
+    }
+    print_commands();
+    return 0;
+}
+
+void get_help_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("command-name", 1);
+    named_opts.add_options()
+        ("command-name", po::value<string>(), "Command name.");
+}
+
+DWORD execute_list(const po::variables_map &vm)
+{
+    return CmdList();
+}
+
+void get_map_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("instance-name", 1)
+                  .add("hostname", 1);
+    named_opts.add_options()
+        ("instance-name", po::value<string>()->required(), "Disk identifier.")
+        ("hostname", po::value<string>()->required(), "NBD server hostname.")
+        ("port", po::value<DWORD>()->default_value(10809),
+            "NBD server port number. Default: 10809.")
+        ("export-name", po::value<string>(),
+            "NBD export name, defaults to <instance-name>.")
+        ("skip-handshake", po::bool_switch(),
+            "Skip NBD handshake and jump right into the transmission phase. "
+            "This is useful for minimal NBD servers. If set, the disk size "
+            "and block size must be provided.")
+        ("disk-size", po::value<UINT64>(),
+            "The disk size. Ignored when using NBD handshake.")
+        ("block-size", po::value<UINT32>(),
+            "The block size. Ignored when using NBD handshake.")
+        ("read-only", po::bool_switch(), "Enable disk read-only mode.");
+}
+
+DWORD execute_map(const po::variables_map& vm)
+{
+    return CmdMap(
+        safe_get_param<string>(vm, "instance-name").c_str(),
+        safe_get_param<string>(vm, "hostname").c_str(),
+        safe_get_param<DWORD>(vm, "port"),
+        safe_get_param<string>(vm, "export-name").c_str(),
+        safe_get_param<UINT64>(vm, "disk-size"),
+        safe_get_param<UINT32>(vm, "block-size"),
+        safe_get_param<bool>(vm, "skip-handshake"),
+        safe_get_param<bool>(vm, "read-only"));
+}
+
+void get_unmap_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("instance-name", 1);
+    named_opts.add_options()
+        ("instance-name", po::value<string>()->required(), "Disk identifier.")
+        ("hard-disconnect", po::bool_switch(), "Perform a hard disconnect.");
+}
+
+DWORD execute_stats(const po::variables_map& vm)
+{
+    return CmdStats(
+        safe_get_param<string>(vm, "instance-name").c_str());
+}
+
+void get_stats_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("instance-name", 1);
+    named_opts.add_options()
+        ("instance-name", po::value<string>()->required(), "Disk identifier.");
+}
+
+// TODO: expose soft unmap parameters
+DWORD execute_unmap(const po::variables_map& vm)
+{
+    return CmdUnmap(
+        safe_get_param<string>(vm, "instance-name").c_str(),
+        safe_get_param<bool>(vm, "hard-disconnect"));
+}
+
+void get_list_opt_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    named_opts.add_options()
+        ("persistent", po::bool_switch(), "List persistent options only.");
+}
+
+DWORD execute_list_opt(const po::variables_map& vm)
+{
+    return CmdListOpt(
+        safe_get_param<bool>(vm, "persistent"));
+}
+
+void get_opt_getter_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("name", 1);
+    named_opts.add_options()
+        ("name", po::value<string>()->required(), "Option name.")
+        ("persistent", po::bool_switch(), "Get the persistent value, if set.");
+}
+
+DWORD execute_get_opt(const po::variables_map& vm)
+{
+    return CmdGetOpt(
+        safe_get_param<string>(vm, "name").c_str(),
+        safe_get_param<bool>(vm, "persistent"));
+}
+
+void get_opt_setter_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("name", 1)
+                  .add("value", 1);
+    named_opts.add_options()
+        ("name", po::value<string>()->required(), "Option name.")
+        ("value", po::value<string>()->required(), "Option value.")
+        ("persistent", po::bool_switch(), "Persist the value across reboots.");
+}
+
+DWORD execute_set_opt(const po::variables_map& vm)
+{
+    return CmdSetOpt(
+        safe_get_param<string>(vm, "name").c_str(),
+        safe_get_param<string>(vm, "value").c_str(),
+        safe_get_param<bool>(vm, "persistent"));
+}
+
+void get_reset_opt_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("name", 1);
+    named_opts.add_options()
+        ("name", po::value<string>()->required(), "Option name.")
+        ("persistent", po::bool_switch(), "Persist the value across reboots.");
+}
+
+DWORD execute_reset_opt(const po::variables_map& vm)
+{
+    return CmdResetOpt(
+        safe_get_param<string>(vm, "name").c_str(),
+        safe_get_param<bool>(vm, "persistent"));
+}
+
+Client::Command commands[] = {
+    Client::Command(
+        "version", {"-v"}, "Get the client, library and driver version.",
+        execute_version),
+    Client::Command(
+        "help", {"-h", "--help"},
+        "List all commands or get more details about a specific command.",
+        execute_help, get_help_args),
+    Client::Command(
+        "list", {"ls"}, "List WNBD disks",
+        execute_list),
+    Client::Command(
+        "map", {}, "Create a new disk mapping, connecting to the "
+                   "specified NBD server.",
+        execute_map, get_map_args),
+    Client::Command(
+        "unmap", {"rm"}, "Remove disk mapping.",
+        execute_unmap, get_unmap_args),
+    Client::Command(
+        "stats", {}, "Get disk stats.",
+        execute_stats, get_stats_args),
+    Client::Command(
+        "list-opt", {}, "List driver options.",
+        execute_list_opt, get_list_opt_args),
+    Client::Command(
+        "get-opt", {}, "Get driver option.",
+        execute_get_opt, get_opt_getter_args),
+    Client::Command(
+        "set-opt", {}, "Set driver option.",
+        execute_set_opt, get_opt_setter_args),
+    Client::Command(
+        "reset-opt", {}, "Reset driver option.",
+        execute_reset_opt, get_reset_opt_args),
+};

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -146,6 +146,20 @@ DWORD execute_list(const po::variables_map &vm)
     return CmdList();
 }
 
+void get_show_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    positonal_opts.add("instance-name", 1);
+    named_opts.add_options()
+        ("instance-name", po::value<string>()->required(), "Disk identifier.");
+}
+
+DWORD execute_show(const po::variables_map &vm)
+{
+    return CmdShow(safe_get_param<string>(vm, "instance-name").c_str());
+}
+
 void get_map_args(
     po::positional_options_description &positonal_opts,
     po::options_description &named_opts)
@@ -313,6 +327,9 @@ Client::Command commands[] = {
     Client::Command(
         "list", {"ls"}, "List WNBD disks",
         execute_list),
+    Client::Command(
+        "show", {}, "Show detailed disk information.",
+        execute_show, get_show_args),
     Client::Command(
         "map", {}, "Create a new disk mapping, connecting to the "
                    "specified NBD server.",

--- a/wnbd-client/client.h
+++ b/wnbd-client/client.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <boost/program_options.hpp>
+
+#include <windows.h>
+
+typedef void (*GetOptionsFunc)(
+    boost::program_options::positional_options_description &positonal_opts,
+    boost::program_options::options_description &named_opts);
+typedef DWORD (*ExecuteFunc)(const boost::program_options::variables_map &vm);
+
+class Client {
+public:
+    struct Command {
+        std::string name;
+        std::vector<std::string> aliases;
+        std::string description;
+
+        ExecuteFunc execute = nullptr;
+        GetOptionsFunc get_options = nullptr;
+
+        Command(std::string _name,
+            std::vector<std::string> _aliases,
+            std::string _description,
+            ExecuteFunc _execute,
+            GetOptionsFunc _get_options = nullptr)
+            : name(_name)
+            , aliases(_aliases)
+            , description(_description)
+            , execute(_execute)
+            , get_options(_get_options)
+        {
+            Client::commands.push_back(this);
+        }
+    };
+
+    static std::vector<Command*> commands;
+    static const size_t LINE_WIDTH = 80;
+    static const size_t MIN_LCOLUMN_WIDTH = 20;
+
+    DWORD execute(int argc, const char** argv);
+    static Command* get_command(std::string name);
+
+    static void get_common_options(boost::program_options::options_description& options);
+};

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -148,15 +148,19 @@ DWORD CmdMap(
     return Status;
 }
 
-DWORD CmdUnmap(PCSTR InstanceName, BOOLEAN HardRemove)
+DWORD CmdUnmap(
+    PCSTR InstanceName,
+    BOOLEAN HardRemove,
+    BOOLEAN NoHardDisonnectFallback,
+    DWORD SoftDisconnectTimeout,
+    DWORD SoftDisconnectRetryInterval)
 {
     WNBD_REMOVE_OPTIONS RemoveOptions = {0};
     RemoveOptions.Flags.HardRemove = HardRemove;
 
-    // TODO: make those configurable. We should use named arguments first.
-    RemoveOptions.Flags.HardRemoveFallback = TRUE;
-    RemoveOptions.SoftRemoveTimeoutMs = WNBD_DEFAULT_RM_TIMEOUT_MS;
-    RemoveOptions.SoftRemoveRetryIntervalMs = WNBD_DEFAULT_RM_RETRY_INTERVAL_MS;
+    RemoveOptions.Flags.HardRemoveFallback = !NoHardDisonnectFallback;
+    RemoveOptions.SoftRemoveTimeoutMs = SoftDisconnectTimeout * 1000;
+    RemoveOptions.SoftRemoveRetryIntervalMs = SoftDisconnectRetryInterval * 1000;
 
     DWORD Status = WnbdRemoveEx(InstanceName, &RemoveOptions);
     return Status;

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -13,9 +13,13 @@
 #include <codecvt>
 #include <locale>
 #include <sstream>
+#include <iostream>
+#include <iomanip>
 
 #pragma comment(lib, "Setupapi.lib")
 #pragma comment(lib, "CfgMgr32.lib")
+
+using namespace std;
 
 std::wstring to_wstring(std::string str)
 {
@@ -174,16 +178,55 @@ DWORD CmdStats(PCSTR InstanceName)
         return Status;
     }
 
-    printf("Disk stats:\n");
-    printf("TotalReceivedIORequests: %llu\n", Stats.TotalReceivedIORequests);
-    printf("TotalSubmittedIORequests: %llu\n", Stats.TotalSubmittedIORequests);
-    printf("TotalReceivedIOReplies: %llu\n", Stats.TotalReceivedIOReplies);
-    printf("UnsubmittedIORequests: %llu\n", Stats.UnsubmittedIORequests);
-    printf("PendingSubmittedIORequests: %llu\n", Stats.PendingSubmittedIORequests);
-    printf("AbortedSubmittedIORequests: %llu\n", Stats.AbortedSubmittedIORequests);
-    printf("AbortedUnsubmittedIORequests: %llu\n", Stats.AbortedUnsubmittedIORequests);
-    printf("CompletedAbortedIORequests: %llu\n", Stats.CompletedAbortedIORequests);
-    printf("OutstandingIOCount: %llu\n", Stats.OutstandingIOCount);
+    cout << "Disk stats" << endl << left
+         << setw(30) << "TotalReceivedIORequests" << " : " <<  Stats.TotalReceivedIORequests << endl
+         << setw(30) << "TotalSubmittedIORequests" << " : " <<  Stats.TotalSubmittedIORequests << endl
+         << setw(30) << "TotalReceivedIOReplies" << " : " <<  Stats.TotalReceivedIOReplies << endl
+         << setw(30) << "UnsubmittedIORequests" << " : " <<  Stats.UnsubmittedIORequests << endl
+         << setw(30) << "PendingSubmittedIORequests" << " : " <<  Stats.PendingSubmittedIORequests << endl
+         << setw(30) << "AbortedSubmittedIORequests" << " : " <<  Stats.AbortedSubmittedIORequests << endl
+         << setw(30) << "AbortedUnsubmittedIORequests" << " : " <<  Stats.AbortedUnsubmittedIORequests << endl
+         << setw(30) << "CompletedAbortedIORequests" << " : " <<  Stats.CompletedAbortedIORequests << endl
+         << setw(30) << "OutstandingIOCount" << " : " <<  Stats.OutstandingIOCount << endl
+         << endl;
+    return Status;
+}
+
+DWORD CmdShow(PCSTR InstanceName)
+{
+    WNBD_CONNECTION_INFO ConnInfo = {0};
+    DWORD Status = WnbdShow(InstanceName, &ConnInfo);
+    if (Status) {
+        return Status;
+    }
+
+    cout << "Connection info" << endl << left
+         << setw(25) << "InstanceName" << " : " <<  ConnInfo.Properties.InstanceName << endl
+         << setw(25) << "SerialNumber" << " : " <<  ConnInfo.Properties.SerialNumber << endl
+         << setw(25) << "Owner" << " : " <<  ConnInfo.Properties.Owner << endl
+         << setw(25) << "ReadOnly" << " : " <<  ConnInfo.Properties.Flags.ReadOnly << endl
+         << setw(25) << "FlushSupported" << " : " <<  ConnInfo.Properties.Flags.FlushSupported << endl
+         << setw(25) << "FUASupported" << " : " <<  ConnInfo.Properties.Flags.FUASupported << endl
+         << setw(25) << "UnmapSupported" << " : " <<  ConnInfo.Properties.Flags.UnmapSupported << endl
+         << setw(25) << "UnmapAnchorSupported " << " : "
+                     << ConnInfo.Properties.Flags.UnmapAnchorSupported << endl
+         << setw(25) << "UseNbd" << " : " <<  ConnInfo.Properties.Flags.UseNbd << endl
+         << setw(25) << "BlockCount" << " : " <<  ConnInfo.Properties.BlockCount << endl
+         << setw(25) << "BlockSize" << " : " <<  ConnInfo.Properties.BlockSize << endl
+         << setw(25) << "MaxUnmapDescCount" << " : " <<  ConnInfo.Properties.MaxUnmapDescCount << endl
+         << setw(25) << "Pid" << " : " <<  ConnInfo.Properties.Pid << endl
+         << endl;
+
+    if (ConnInfo.Properties.Flags.UseNbd) {
+        cout << "Nbd properties" << endl << left
+             << setw(25) << "Hostname" << " : " << ConnInfo.Properties.NbdProperties.Hostname << endl
+             << setw(25) << "PortNumber" << " : " << ConnInfo.Properties.NbdProperties.PortNumber << endl
+             << setw(25) << "ExportName" << " : " << ConnInfo.Properties.NbdProperties.ExportName << endl
+             << setw(25) << "SkipNegotiation" << " : "
+                         << ConnInfo.Properties.NbdProperties.Flags.SkipNegotiation << endl
+             << endl;
+    }
+
     return Status;
 }
 
@@ -228,7 +271,6 @@ DWORD GetList(PWNBD_CONNECTION_LIST* ConnectionList)
     return Status;
 }
 
-// TODO: add CmdShow
 DWORD CmdList()
 {
     PWNBD_CONNECTION_LIST ConnList = NULL;

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -21,33 +21,27 @@
 
 using namespace std;
 
-std::wstring to_wstring(std::string str)
+wstring to_wstring(string str)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
+    wstring_convert<codecvt_utf8<wchar_t>, wchar_t> strconverter;
     return strconverter.from_bytes(str);
 }
 
-std::string to_string(std::wstring wstr)
+wstring OptValToWString(PWNBD_OPTION_VALUE Value)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> strconverter;
-    return strconverter.to_bytes(wstr);
-}
-
-std::string OptValToString(PWNBD_OPTION_VALUE Value)
-{
-    std::ostringstream stream;
+    wostringstream stream;
     switch(Value->Type) {
     case WnbdOptBool:
-        stream << (Value->Data.AsBool ? "true" : "false");
+        stream << (Value->Data.AsBool ? L"true" : L"false");
         break;
     case WnbdOptInt64:
         stream << Value->Data.AsInt64;
         break;
     case WnbdOptWstr:
-        stream << to_string(Value->Data.AsWstr);
+        stream << wstring(Value->Data.AsWstr);
         break;
     default:
-        stream << "UNKNOWN TYPE (" << Value->Type << ")";
+        stream << L"UNKNOWN TYPE (" << Value->Type << ")";
         break;
     }
 
@@ -70,8 +64,8 @@ void PrintFormattedError(DWORD Error)
         NULL
     );
 
-    fprintf(stderr, "Error code: %d. Error message: %s\n",
-            Error, (LPTSTR)LpMsgBuf);
+    cerr << "Error code: " << Error
+         << ". Error message: " << LpMsgBuf << endl,
 
     LocalFree(LpMsgBuf);
 }
@@ -82,34 +76,37 @@ void PrintLastError()
 }
 
 DWORD CmdMap(
-    PCSTR InstanceName,
-    PCSTR HostName,
+    string InstanceName,
+    string HostName,
     DWORD PortNumber,
-    PCSTR ExportName,
+    string ExportName,
     UINT64 DiskSize,
     UINT32 BlockSize,
     BOOLEAN SkipNegotiation,
     BOOLEAN ReadOnly)
 {
     if (!PortNumber) {
-        fprintf(stderr, "Missing NBD server port number.\n");
+        cerr << "Missing NBD server port number." << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+    if (PortNumber > 65353) {
+        cerr << "Invalid NBD server port number: " << PortNumber << endl;
         return ERROR_INVALID_PARAMETER;
     }
     if (SkipNegotiation && !(BlockSize && DiskSize)) {
-        fprintf(stderr,
-                "The disk size and block size must be provided when "
-                "skipping NBD negotiation.\n");
+        cerr << "The disk size and block size must be provided when "
+                "skipping NBD negotiation" << endl;
         return ERROR_INVALID_PARAMETER;
     }
-    if (!strlen(ExportName)) {
+    if (ExportName.empty()) {
         ExportName = InstanceName;
     }
-    if (!strlen(InstanceName)) {
-        fprintf(stderr, "Missing instace name.\n");
+    if (InstanceName.empty()) {
+        cerr << "Missing instace name." << endl;
         return ERROR_INVALID_PARAMETER;
     }
-    if (!strlen(HostName)) {
-        fprintf(stderr, "Missing NBD hostname.\n");
+    if (HostName.empty()) {
+        cerr << "Missing NBD hostname." << endl;
         return ERROR_INVALID_PARAMETER;
     }
 
@@ -117,24 +114,18 @@ DWORD CmdMap(
     HANDLE WnbdDriverHandle = INVALID_HANDLE_VALUE;
     DWORD Status = WnbdOpenAdapter(&WnbdDriverHandle);
     if (Status) {
-        fprintf(
-            stderr,
-            "Could not open WNBD device. Make sure that the driver "
-            "is installed.\n");
+        cerr << "Could not open WNBD device. Make sure that the driver "
+                "is installed." << endl;
         return Status;
     }
 
-    memcpy(&Props.InstanceName, InstanceName,
-        min(strlen(InstanceName) + 1, WNBD_MAX_NAME_LENGTH));
-    memcpy(&Props.SerialNumber, InstanceName,
-        min(strlen(InstanceName) + 1, WNBD_MAX_NAME_LENGTH));
-    memcpy(&Props.Owner, WNBD_CLI_OWNER_NAME,
-        strlen(WNBD_CLI_OWNER_NAME));
+    InstanceName.copy((char*)&Props.InstanceName, WNBD_MAX_NAME_LENGTH);
+    InstanceName.copy((char*)&Props.SerialNumber, WNBD_MAX_NAME_LENGTH);
+    string(WNBD_CLI_OWNER_NAME).copy((char*)&Props.Owner, WNBD_MAX_OWNER_LENGTH);
 
-    memcpy(&Props.NbdProperties.Hostname, HostName,
-        min(strlen(HostName) + 1, WNBD_MAX_NAME_LENGTH));
-    memcpy(&Props.NbdProperties.ExportName, ExportName,
-        min(strlen(ExportName) + 1, WNBD_MAX_NAME_LENGTH));
+    HostName.copy((char*)&Props.NbdProperties.Hostname, WNBD_MAX_NAME_LENGTH);
+    ExportName.copy((char*)&Props.NbdProperties.ExportName, WNBD_MAX_NAME_LENGTH);
+
     Props.NbdProperties.PortNumber = PortNumber;
     Props.NbdProperties.Flags.SkipNegotiation = SkipNegotiation;
 
@@ -153,7 +144,7 @@ DWORD CmdMap(
 }
 
 DWORD CmdUnmap(
-    PCSTR InstanceName,
+    string InstanceName,
     BOOLEAN HardRemove,
     BOOLEAN NoHardDisonnectFallback,
     DWORD SoftDisconnectTimeout,
@@ -166,14 +157,14 @@ DWORD CmdUnmap(
     RemoveOptions.SoftRemoveTimeoutMs = SoftDisconnectTimeout * 1000;
     RemoveOptions.SoftRemoveRetryIntervalMs = SoftDisconnectRetryInterval * 1000;
 
-    DWORD Status = WnbdRemoveEx(InstanceName, &RemoveOptions);
+    DWORD Status = WnbdRemoveEx(InstanceName.c_str(), &RemoveOptions);
     return Status;
 }
 
-DWORD CmdStats(PCSTR InstanceName)
+DWORD CmdStats(string InstanceName)
 {
     WNBD_DRV_STATS Stats = {0};
-    DWORD Status = WnbdGetDriverStats(InstanceName, &Stats);
+    DWORD Status = WnbdGetDriverStats(InstanceName.c_str(), &Stats);
     if (Status) {
         return Status;
     }
@@ -192,10 +183,10 @@ DWORD CmdStats(PCSTR InstanceName)
     return Status;
 }
 
-DWORD CmdShow(PCSTR InstanceName)
+DWORD CmdShow(string InstanceName)
 {
     WNBD_CONNECTION_INFO ConnInfo = {0};
-    DWORD Status = WnbdShow(InstanceName, &ConnInfo);
+    DWORD Status = WnbdShow(InstanceName.c_str(), &ConnInfo);
     if (Status) {
         return Status;
     }
@@ -246,7 +237,7 @@ DWORD GetList(PWNBD_CONNECTION_LIST* ConnectionList)
         if (BufferSize) {
             TempList = (PWNBD_CONNECTION_LIST) calloc(1, BufferSize);
             if (!TempList) {
-                fprintf(stderr, "Could not allocate %d bytes.\n", BufferSize);
+                cerr << "Could not allocate " << BufferSize << " bytes." << endl;
                 Status = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }
@@ -280,72 +271,79 @@ DWORD CmdList()
     }
 
     DWORD Status = 0;
-    printf("%-10s  %-10s  %-5s  %-15s  %s\n", "Pid", "DiskNumber", "Nbd", "Owner", "InstanceName");
+    cout << left
+         << setw(10) << "Pid" << "  "
+         << setw(10) << "DiskNumber" << "  "
+         << setw(5) << "Nbd" << "  "
+         << setw(15) << "Owner" << "  "
+         << "InstanceName" << endl;
+
     for (ULONG index = 0; index < ConnList->Count; index++) {
-        std::wstring SerialNumberW = to_wstring(
+        wstring SerialNumberW = to_wstring(
             ConnList->Connections[index].Properties.SerialNumber);
         DWORD DiskNumber = -1;
         HRESULT hres = WnbdGetDiskNumberBySerialNumber(
             SerialNumberW.c_str(), &DiskNumber);
         if (FAILED(hres)) {
-            fprintf(stderr,
-                    "Warning: Could not retrieve disk number for serial '%ls'. "
-                    "HRESULT: 0x%x.\n", SerialNumberW.c_str(), hres);
+            wcerr << "Warning: Could not retrieve disk number for serial '"
+                  << SerialNumberW << "'." << "HRESULT: " << hex << hres << endl;
             Status = HRESULT_CODE(hres);
         }
-        printf("%-10d  %-10d  %-5s  %-15s  %s\n",
-               ConnList->Connections[index].Properties.Pid,
-               DiskNumber,
-               ConnList->Connections[index].Properties.Flags.UseNbd ? "true" : "false",
-               ConnList->Connections[index].Properties.Owner,
-               ConnList->Connections[index].Properties.InstanceName);
+        cout << left
+             << setw(10) << ConnList->Connections[index].Properties.Pid << "  "
+             << setw(10) << DiskNumber << "  "
+             << setw(5) << (ConnList->Connections[index].Properties.Flags.UseNbd
+                            ? "true" : "false") << "  "
+             << setw(15) << ConnList->Connections[index].Properties.Owner << "  "
+             << ConnList->Connections[index].Properties.InstanceName << endl;
     }
     free(ConnList);
     return Status;
 }
 
-DWORD CmdVersion() {
-    printf("wnbd-client.exe: %s\n", WNBD_VERSION_STR);
+DWORD CmdVersion()
+{
+    cout << "wnbd-client.exe: " << WNBD_VERSION_STR << endl;
 
     WNBD_VERSION Version = { 0 };
     WnbdGetLibVersion(&Version);
-    printf("libwnbd.dll: %s\n", Version.Description);
+    cout << "libwnbd.dll: " << Version.Description << endl;
 
     Version = { 0 };
     DWORD Status = WnbdGetDriverVersion(&Version);
     if (!Status) {
-        printf("wnbd.sys: %s\n", Version.Description);
+        cout << "wnbd.sys: " << Version.Description << endl;
     }
 
     return Status;
 }
 
 DWORD
-CmdGetOpt(const char* Name, BOOLEAN Persistent)
+CmdGetOpt(string Name, BOOLEAN Persistent)
 {
     WNBD_OPTION_VALUE Value;
-    DWORD Status = WnbdGetDrvOpt(Name, &Value, Persistent);
+    DWORD Status = WnbdGetDrvOpt(Name.c_str(), &Value, Persistent);
     if (Status) {
         return Status;
     }
 
-    printf("Name: %s\n", Name);
-    printf("Value: %s\n", OptValToString(&Value).c_str());
+    wcout << L"Name: " << to_wstring(Name) << endl
+          << L"Value: " << OptValToWString(&Value).c_str() << endl;
     return Status;
 }
 
 DWORD
-CmdSetOpt(const char* Name, const char* Value, BOOLEAN Persistent)
+CmdSetOpt(string Name, string Value, BOOLEAN Persistent)
 {
     WNBD_OPTION_VALUE OptValue = { WnbdOptWstr };
     to_wstring(Value).copy((PWCHAR)&OptValue.Data.AsWstr, WNBD_MAX_NAME_LENGTH);
-    return WnbdSetDrvOpt(Name, &OptValue, Persistent);
+    return WnbdSetDrvOpt(Name.c_str(), &OptValue, Persistent);
 }
 
 DWORD
-CmdResetOpt(const char* Name, BOOLEAN Persistent)
+CmdResetOpt(string Name, BOOLEAN Persistent)
 {
-    return WnbdResetDrvOpt(Name, Persistent);
+    return WnbdResetDrvOpt(Name.c_str(), Persistent);
 }
 
 DWORD GetOptList(PWNBD_OPTION_LIST* OptionList, BOOLEAN Persistent)
@@ -362,7 +360,7 @@ DWORD GetOptList(PWNBD_OPTION_LIST* OptionList, BOOLEAN Persistent)
         if (BufferSize) {
             TempList = (PWNBD_OPTION_LIST) calloc(1, BufferSize);
             if (!TempList) {
-                fprintf(stderr, "Could not allocate %d bytes.\n", BufferSize);
+                cerr << "Could not allocate " << BufferSize << " bytes." << endl;
                 Status = ERROR_NOT_ENOUGH_MEMORY;
                 break;
             }
@@ -395,13 +393,20 @@ CmdListOpt(BOOLEAN Persistent)
         return Status;
     }
 
+    size_t Width = 0;
     for (ULONG index = 0; index < OptList->Count; index++) {
         PWNBD_OPTION Option = &OptList->Options[index];
-        printf(
-            "%s: %s (Default: %s)\n",
-            to_string(Option->Name).c_str(),
-            OptValToString(&Option->Value).c_str(),
-            OptValToString(&Option->Default).c_str());
+        Width = max(Width, wcslen(Option->Name));
+    }
+
+    for (ULONG index = 0; index < OptList->Count; index++) {
+        PWNBD_OPTION Option = &OptList->Options[index];
+        wcout << left << setw(Width) << Option->Name
+              << L" : "
+              << OptValToWString(&Option->Value)
+              << L" (Default: "
+              << OptValToWString(&Option->Default)
+              << L")" << endl;
     }
 
     free(OptList);

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -30,7 +30,12 @@ void
 PrintSyntax();
 
 DWORD
-CmdUnmap(PCSTR InstanceName, BOOLEAN HardRemove);
+CmdUnmap(
+    PCSTR InstanceName,
+    BOOLEAN HardRemove,
+    BOOLEAN NoHardDisonnectFallback,
+    DWORD SoftDisconnectTimeout,
+    DWORD SoftDisconnectRetryInterval);
 
 DWORD
 CmdStats(PCSTR InstanceName);

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -55,6 +55,9 @@ DWORD
 CmdList();
 
 DWORD
+CmdShow(PCSTR InstanceName);
+
+DWORD
 CmdVersion();
 
 DWORD

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -30,17 +30,17 @@ void
 PrintSyntax();
 
 DWORD
-CmdUnmap(PCHAR InstanceName, BOOLEAN HardRemove);
+CmdUnmap(PCSTR InstanceName, BOOLEAN HardRemove);
 
 DWORD
-CmdStats(PCHAR InstanceName);
+CmdStats(PCSTR InstanceName);
 
 DWORD
 CmdMap(
-    PCHAR InstanceName,
-    PCHAR HostName,
+    PCSTR InstanceName,
+    PCSTR HostName,
     DWORD PortNumber,
-    PCHAR ExportName,
+    PCSTR ExportName,
     UINT64 DiskSize,
     UINT32 BlockSize,
     BOOLEAN MustNegotiate,

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -6,10 +6,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <windows.h>
 #include <winioctl.h>
 #include <shlobj.h>
@@ -21,6 +17,8 @@ extern "C" {
 #include <string.h>
 #include <process.h>
 
+#include <string>
+
 /* WNBD Defines */
 #include "wnbd.h"
 
@@ -31,21 +29,21 @@ PrintSyntax();
 
 DWORD
 CmdUnmap(
-    PCSTR InstanceName,
+    std::string InstanceName,
     BOOLEAN HardRemove,
     BOOLEAN NoHardDisonnectFallback,
     DWORD SoftDisconnectTimeout,
     DWORD SoftDisconnectRetryInterval);
 
 DWORD
-CmdStats(PCSTR InstanceName);
+CmdStats(std::string InstanceName);
 
 DWORD
 CmdMap(
-    PCSTR InstanceName,
-    PCSTR HostName,
+    std::string InstanceName,
+    std::string HostName,
     DWORD PortNumber,
-    PCSTR ExportName,
+    std::string ExportName,
     UINT64 DiskSize,
     UINT32 BlockSize,
     BOOLEAN MustNegotiate,
@@ -55,23 +53,19 @@ DWORD
 CmdList();
 
 DWORD
-CmdShow(PCSTR InstanceName);
+CmdShow(std::string InstanceName);
 
 DWORD
 CmdVersion();
 
 DWORD
-CmdGetOpt(const char* Name, BOOLEAN Persistent);
+CmdGetOpt(std::string Name, BOOLEAN Persistent);
 
 DWORD
-CmdSetOpt(const char* Name, const char* Value, BOOLEAN Persistent);
+CmdSetOpt(std::string Name, std::string Value, BOOLEAN Persistent);
 
 DWORD
-CmdResetOpt(const char* Name, BOOLEAN Persistent);
+CmdResetOpt(std::string Name, BOOLEAN Persistent);
 
 DWORD
 CmdListOpt(BOOLEAN Persistent);
-
-#ifdef __cplusplus
-}
-#endif

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -4,31 +4,14 @@
  * Licensed under LGPL-2.1 (see LICENSE)
  */
 
-#include "cmd.h"
+#include "client.h"
+
 #include <string>
 
-bool arg_to_bool(char* arg) {
-    return !_stricmp(arg, "1") ||
-           !_stricmp(arg, "t") ||
-           !_stricmp(arg, "true") ||
-           !_stricmp(arg, "yes") ||
-           !_stricmp(arg, "y");
-}
+#include <wnbd.h>
 
-int main(int argc, PCHAR argv[])
+int main(int argc, const char** argv)
 {
-    PCHAR Command;
-    PCHAR InstanceName = NULL;
-    DWORD PortNumber = NULL;
-    PCHAR ExportName = NULL;
-    PCHAR HostName = NULL;
-
-    BOOLEAN PersistentOpt = FALSE;
-    PCHAR OptName = NULL;
-    PCHAR OptValue = NULL;
-
-    Command = argv[1];
-
     // This must be called only once. We're going to do it as early as
     // possible to avoid having issues because of uninitialized COM.
     HRESULT hres = WnbdCoInitializeBasic();
@@ -36,75 +19,5 @@ int main(int argc, PCHAR argv[])
         return HRESULT_CODE(hres);
     }
 
-    if ((argc >= 6) && !strcmp(Command, "map")) {
-        InstanceName = argv[2];
-        HostName = argv[3];
-        PortNumber = atoi(argv[4]);
-        ExportName = argv[5];
-        BOOLEAN SkipNegotiation = FALSE;
-        BOOLEAN ReadOnly = FALSE;
-        UINT32 DiskSize = 0;
-        UINT32 BlockSize = 512;
-
-        // TODO: use named arguments.
-        if (argc > 6) {
-            SkipNegotiation = arg_to_bool(argv[6]);
-        }
-        if (argc > 7) {
-            ReadOnly = arg_to_bool(argv[7]);
-        }
-        if (argc > 8) {
-            DiskSize = atoi(argv[8]);
-        }
-        if (argc > 9) {
-            BlockSize = atoi(argv[9]);
-        }
-
-        CmdMap(InstanceName, HostName, PortNumber, ExportName, DiskSize,
-               BlockSize, SkipNegotiation, ReadOnly);
-    } else if (argc >= 3 && !strcmp(Command, "unmap")) {
-        InstanceName = argv[2];
-        BOOLEAN HardRemove = FALSE;
-        if (argc > 3) {
-            HardRemove = arg_to_bool(argv[3]);
-        }
-        CmdUnmap(InstanceName, HardRemove);
-    } else if (argc == 3 && !strcmp(Command, "stats")) {
-        InstanceName = argv[2];
-        CmdStats(InstanceName);
-    } else if (argc == 2 && !strcmp(Command, "list")) {
-        return CmdList();
-    } else if (argc == 2 && (
-            !strcmp(Command, "version") || !strcmp(Command, "-v"))) {
-        return CmdVersion();
-    } else if (argc >= 2 && !strcmp(Command, "list-opt")) {
-        if (argc > 2) {
-            PersistentOpt = arg_to_bool(argv[2]);
-        }
-        CmdListOpt(PersistentOpt);
-    } else if (argc >= 3 && !strcmp(Command, "get-opt")) {
-        OptName = argv[2];
-        if (argc > 3) {
-            PersistentOpt = arg_to_bool(argv[3]);
-        }
-        CmdGetOpt(OptName, PersistentOpt);
-    } else if (argc >= 3 && !strcmp(Command, "reset-opt")) {
-        OptName = argv[2];
-        if (argc > 3) {
-            PersistentOpt = arg_to_bool(argv[3]);
-        }
-        CmdResetOpt(OptName, PersistentOpt);
-    } else if (argc >= 4 && !strcmp(Command, "set-opt")) {
-        OptName = argv[2];
-        OptValue = argv[3];
-        if (argc > 4) {
-            PersistentOpt = arg_to_bool(argv[4]);
-        }
-        CmdSetOpt(OptName, OptValue, PersistentOpt);
-    } else {
-        PrintSyntax();
-        return -1;
-    }
-    
-    return 0;
+    return Client().execute(argc, argv);
 }

--- a/wnbd-client/usage.cc
+++ b/wnbd-client/usage.cc
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "client.h"
+#include "usage.h"
+
+#include <iostream>
+#include <iomanip>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/join.hpp>
+
+namespace po = boost::program_options;
+using namespace std;
+
+string fmt_text(size_t margin, size_t width, string text)
+{
+    string result;
+    boost::trim(text);
+    while (!text.empty())
+    {
+        // Don't apply padding to the first line.
+        if (!result.empty()) {
+            result += string(margin, ' ');
+        }
+
+        // The text size exceeds the line width so we're trying to find
+        // the best place to break the line.
+        size_t n = text.size();
+        if (text.size() > width) {
+            n = text.rfind(" ", width);
+            if (n == string::npos) {
+                n = text.find(" ");
+            }
+            if (n == string::npos) {
+                n = text.length();
+            }
+        }
+        // We'll preserve newlines.
+        n = min(n, text.find("\n"));
+
+        result += text.substr(0, n);
+        text.erase(0, n);
+        boost::trim(text);
+
+        if (!text.empty()) {
+            result += "\n";
+        }
+    }
+    return result;
+}
+
+string fmt_pos_opt_short(std::string opt_name)
+{
+    ostringstream s;
+    s << "<" << opt_name << ">";
+    return s.str();
+}
+
+string fmt_opt_short(boost::shared_ptr<po::option_description> option)
+{
+    ostringstream s;
+    bool required = option->semantic()->is_required();
+    if (!required) {
+        s << "[";
+    }
+    s << "--" << option->long_name();
+    if (option->semantic()->max_tokens() != 0) {
+        s << " <arg>";
+    }
+    if (!required) {
+        s << "]";
+    }
+    return s.str();
+}
+
+void print_option_details(
+    po::positional_options_description &positional_opts,
+    po::options_description &named_opts,
+    size_t& lcol_width,
+    std::string optional_args_title = "Optional arguments")
+{
+    map<string, string> pos_opt_desc;
+    ostringstream pos_stream;
+
+    // Right column margin.
+    size_t option_indent = 2;
+    lcol_width = max(lcol_width, Client::MIN_LCOLUMN_WIDTH);
+    string last_pos_opt;
+    for (unsigned int i = 0; i < positional_opts.max_total_count(); i++)
+    {
+        auto opt_name = positional_opts.name_for_position(i);
+        if (opt_name == last_pos_opt) {
+            break;
+        }
+        // Determine the margin and prepare a mapping with positional
+        // option descriptions. The actual descriptions will be filled
+        // when handling the named opts.
+        pos_opt_desc.insert(pair<string, string>(opt_name, ""));
+        lcol_width = max(lcol_width, opt_name.length() + 3 + option_indent);
+    }
+
+    ostringstream ops_stream;
+    size_t optional_arg_count = 0;
+    for (auto named_opt : named_opts.options())
+    {
+        auto opt_name = named_opt->long_name();
+        auto it = pos_opt_desc.find(opt_name);
+        if (it != pos_opt_desc.end()) {
+            it->second = named_opt->description();
+            continue;
+        }
+        optional_arg_count += 1;
+        lcol_width = max(lcol_width,
+                     fmt_opt_short(named_opt).length() + 1 + option_indent);
+    }
+
+    if (!pos_opt_desc.empty()) {
+        cout << "Positional arguments:" << endl;
+        for (auto pos_opt : pos_opt_desc) {
+            string formatted_desc = fmt_text(
+                lcol_width,
+                max(Client::LINE_WIDTH - lcol_width, Client::LINE_WIDTH / 3),
+                pos_opt.second);
+            cout << left << string(option_indent, ' ')
+                 << setw(lcol_width - option_indent)
+                 << fmt_pos_opt_short(pos_opt.first)
+                 << formatted_desc << endl;
+        }
+        cout << endl;
+    }
+
+    if (optional_arg_count) {
+        cout << optional_args_title << ":" << endl;
+        for (auto named_opt : named_opts.options())
+        {
+            auto opt_name = named_opt->long_name();
+            // Already printed.
+            if (pos_opt_desc.find(opt_name) != pos_opt_desc.end()) {
+                continue;
+            }
+            string formatted_desc = fmt_text(
+                lcol_width,
+                max(Client::LINE_WIDTH - lcol_width, Client::LINE_WIDTH / 3),
+                named_opt->description());
+            cout << left
+                 << string(option_indent, ' ')
+                 << setw(lcol_width - option_indent)
+                 << fmt_opt_short(named_opt)
+                 << formatted_desc << endl;
+        }
+        cout << endl;
+    }
+}
+
+void print_command_usage(
+    string binary_name,
+    string command_name,
+    po::positional_options_description &positional_opts,
+    po::options_description &named_opts)
+{
+    string usage_str = "Usage: " + binary_name + " " + command_name;
+    size_t margin = usage_str.length() + 1;
+
+    set<string> pos_opt_names;
+    ostringstream pos_stream;
+
+    string last_pos_opt;
+    for (unsigned int i = 0; i < positional_opts.max_total_count(); i++)
+    {
+        auto opt_name = positional_opts.name_for_position(i);
+        if (opt_name == last_pos_opt) {
+            pos_stream << " [<" << opt_name << "> ...]";
+            break;
+        }
+        pos_stream << "<" << opt_name << "> ";
+        pos_opt_names.insert(opt_name);
+    }
+
+    ostringstream ops_stream;
+    for (auto named_opt : named_opts.options())
+    {
+        auto opt_name = named_opt->long_name();
+        if (pos_opt_names.find(opt_name) != pos_opt_names.end()) {
+            continue;
+        }
+        ops_stream << fmt_opt_short(named_opt) << " ";
+    }
+
+    string formatted_opts = fmt_text(
+        margin,
+        max(Client::LINE_WIDTH - margin - 1, Client::LINE_WIDTH / 3),
+        boost::algorithm::join(vector<string>({pos_stream.str(), ops_stream.str()}), "\n"));
+
+    cout << usage_str << " " << formatted_opts << endl;
+}
+
+DWORD print_command_help(string command_name)
+{
+    auto command = Client::get_command(command_name);
+    if (!command) {
+        cerr << "Unknown command: " << command_name << endl;
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    po::positional_options_description positional_opts;
+    po::options_description named_opts;
+
+    if (command->get_options) {
+        command->get_options(positional_opts, named_opts);
+    }
+
+    print_command_usage("wnbd-client", command->name,
+                        positional_opts, named_opts);
+
+    cout << endl << fmt_text(0, Client::LINE_WIDTH, command->description)
+         << endl << endl;
+
+    // Use a consistent indentation for option groups.
+    size_t lcol_width = Client::MIN_LCOLUMN_WIDTH;
+    print_option_details(positional_opts, named_opts, lcol_width);
+
+    // There aren't common positional arguments.
+    po::positional_options_description common_pos_opts;
+    po::options_description common_opts;
+    Client::get_common_options(common_opts);
+    print_option_details(common_pos_opts, common_opts, lcol_width,
+                         "Common arguments");
+
+    return 0;
+}
+
+void print_commands()
+{
+    cout << "wnbd-client commands: " << endl << endl;
+
+    size_t name_col_width = 0;
+    for (Client::Command *command : Client::commands)
+    {
+        size_t width = command->name.length();
+        if (!command->aliases.empty()) {
+            for (auto alias: command->aliases) {
+                width += alias.length();
+            }
+        }
+        width += (command->aliases.size() * 3);
+        name_col_width = max(name_col_width, width);
+    }
+    for (Client::Command *command : Client::commands)
+    {
+        vector<string> cmd_names;
+        cmd_names.push_back(command->name);
+        cmd_names.insert(
+            cmd_names.end(), command->aliases.begin(),
+            command->aliases.end());
+        string joined_cmd_names = boost::algorithm::join(cmd_names, " | ");
+        string formatted_desc = fmt_text(
+            name_col_width + 1,
+            max(Client::LINE_WIDTH - name_col_width, Client::LINE_WIDTH / 3),
+            command->description);
+        cout << left << setw(name_col_width) << joined_cmd_names
+             << " " << formatted_desc << endl;
+    }
+}

--- a/wnbd-client/usage.h
+++ b/wnbd-client/usage.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string>
+
+DWORD print_command_help(std::string command_name);
+void print_commands();

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -96,6 +96,7 @@
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
+      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
@@ -121,6 +122,7 @@
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
+      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -142,6 +144,7 @@
     </Link>
     <PreBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
+      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -151,7 +154,19 @@
   <ItemGroup>
     <ClInclude Include="cmd.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config"/>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets" Condition="Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" AfterTargets="PreBuildEvent">
+    <PropertyGroup>
+      <ErrorText>Missing dependency: {0}. Please use "get_dependencies.ps1" before building WNBD.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets'))" />
+  </Target>
 </Project>

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -148,14 +148,18 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="client.cpp" />
     <ClCompile Include="cmd.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="usage.cc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="client.h" />
     <ClInclude Include="cmd.h" />
+    <ClInclude Include="usage.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config"/>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -94,10 +94,6 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -120,10 +116,6 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -142,10 +134,6 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
-    <PreBuildEvent>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\generate_version_h.ps1"</Command>
-      <Command>powershell.exe -executionpolicy bypass -file "$(SolutionDir)\..\get_dependencies.ps1"</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="client.cpp" />
@@ -166,11 +154,4 @@
     <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets" Condition="Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" />
   </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" AfterTargets="PreBuildEvent">
-    <PropertyGroup>
-      <ErrorText>Missing dependency: {0}. Please use "get_dependencies.ps1" before building WNBD.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets'))" />
-  </Target>
 </Project>


### PR DESCRIPTION
At the moment, wnbd-client only uses positional arguments. This
is highly inconvenient as we're adding more arguments.

For example, the "wnbd-client map" syntax looks like this:
``wnbd-client map  <InstanceName> <HostName> <PortName> <ExportName>
                 [<SkipNBDNegotiation> <ReadOnly> <DiskSize> <BlockSize>]``

This change adds named optional arguments as well as a simple
mechanism of defining command options using Boost. This also allows
us to automatically generate better help strings.

While at it, we're adding a "--debug" option and expose soft disconnect
parameters.