### PR TITLE
Add driver properties through resource file

### DIFF
--- a/driver/wnbd.rc
+++ b/driver/wnbd.rc
@@ -24,6 +24,7 @@
 #include <windows.h>
 #include <ntverp.h>
 #include "..\include\version.h"
+#include "..\include\vendor.h"
 
 #define VER_INTERNALNAME_STR        "wnbd.sys"
 #define VER_ORIGINALFILENAME_STR    "wnbd.sys"
@@ -38,12 +39,12 @@
 #define VER_FILEVERSION_STR         WNBD_VERSION_STR_MS
 
 #undef VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR        "SUSE LLC"
+#define VER_COMPANYNAME_STR         WNBD_COMPANY_STR
 
 #undef VER_FILEDESCRIPTION_STR
 #undef VER_PRODUCTNAME_STR
-#define VER_FILEDESCRIPTION_STR     "Windows Network Block Device"
-#define VER_PRODUCTNAME_STR         "SUSE Enterprise Storage Driver for Windows"
+#define VER_FILEDESCRIPTION_STR     WNBD_FILEDESCRIPTION_STR
+#define VER_PRODUCTNAME_STR         WNBD_PRODUCTNAME_STR
 
 #define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
 

--- a/driver/wnbd.rc
+++ b/driver/wnbd.rc
@@ -1,0 +1,58 @@
+/*-
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (C) 2019-2020 SUSE LLC
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the
+ *
+ *  Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ *
+ */
+
+#include <windows.h>
+#include <ntverp.h>
+#include "..\include\version.h"
+
+#define VER_INTERNALNAME_STR        "wnbd.sys"
+#define VER_ORIGINALFILENAME_STR    "wnbd.sys"
+
+#undef VER_PRODUCTVERSION
+#define VER_PRODUCTVERSION          WNBD_VERSION_MAJOR,WNBD_VERSION_MINOR,WNBD_VERSION_PATCH,WNBD_COMMIT_COUNT
+
+#undef VER_PRODUCTVERSION_STR
+#define VER_PRODUCTVERSION_STR      WNBD_VERSION_STR
+
+#define VER_FILEVERSION             WNBD_VERSION_MAJOR,WNBD_VERSION_MINOR,WNBD_VERSION_PATCH,WNBD_COMMIT_COUNT
+#define VER_FILEVERSION_STR         WNBD_VERSION_STR_MS
+
+#undef VER_COMPANYNAME_STR
+#define VER_COMPANYNAME_STR        "SUSE LLC"
+
+#undef VER_FILEDESCRIPTION_STR
+#undef VER_PRODUCTNAME_STR
+#define VER_FILEDESCRIPTION_STR     "Windows Network Block Device"
+#define VER_PRODUCTNAME_STR         "SUSE Enterprise Storage Driver for Windows"
+
+#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
+
+#define VER_FILETYPE                VFT_DRV
+
+#define VER_LEGALCOPYRIGHT_STR      "Copyright \251 2019-2020 SUSE LLC All rights reserved.", "\0"
+
+/* Strings to be translated */
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#include "common.ver"

--- a/include/vendor.h
+++ b/include/vendor.h
@@ -1,0 +1,10 @@
+/*-
+ * The variables in this vendor.h file can be used to provide vendor specific
+ * strings to the properities of the WNBD driver. Replace the contents of
+ * this file as necessary.
+ */
+
+#define WNBD_COMPANY_STR "WNBD"
+#define WNBD_FILEDESCRIPTION_STR "WNBD"
+#define WNBD_PRODUCTNAME_STR "WNBD"
+

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -144,6 +144,9 @@
     <ClInclude Include="..\driver\util.h" />
     <ClInclude Include="..\driver\wnbd_dispatch.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\driver\wnbd.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/vstudio/driver.vcxproj.filters
+++ b/vstudio/driver.vcxproj.filters
@@ -105,4 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\driver\wnbd.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/vstudio/generate_version_h.ps1
+++ b/vstudio/generate_version_h.ps1
@@ -8,6 +8,8 @@ $versionHeaderPath = "$scriptLocation/../include/version.h"
 $gitShortDesc = git describe --tags
 $gitLongDesc = git describe --tags --long
 $gitTag = git describe --tags --abbrev=0
+$gitBranch = git branch --show-current
+$gitCommitCount = git rev-list --count "$gitTag..$gitBranch"
 
 $isDev = (($gitLongDesc) -split "-")[-2] -ne "0"
 
@@ -20,6 +22,7 @@ $versionMajor = $Matches.major
 $versionMinor = $Matches.minor
 $versionPatch = $Matches.patch
 $versionStr = "$gitShortDesc"
+$versionStrMS = "$versionMajor.$versionMinor.$versionPatch.$gitCommitCount"
 
 # We might add some more info to the version string.
 $versionStrMaxLen = 127
@@ -36,8 +39,10 @@ $versionHeader = @"
 #define WNBD_VERSION_MAJOR ${versionMajor}
 #define WNBD_VERSION_MINOR ${versionMinor}
 #define WNBD_VERSION_PATCH ${versionPatch}
+#define WNBD_COMMIT_COUNT ${gitCommitCount}
 
 #define WNBD_VERSION_STR "${versionStr}"
+#define WNBD_VERSION_STR_MS "${versionStrMS}"
 "@
 
 echo $versionHeader | out-file -encoding utf8 -filepath $versionHeaderPath


### PR DESCRIPTION
Versioning and other details should be visible through properties on the driver file (through Windows Explorer). As Windows versions commonly use a four digit versioning scheme (x.x.x.x), use the git commit count as the fourth digit.