### PR TITLE
driver: clean up IO queue when resetting adapter

### DIFF
--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -41,7 +41,14 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
     }
 
     DrainDeviceQueue(Device, FALSE);
-    AbortSubmittedRequests(Device);
+    if (Device->Properties.Flags.UseNbd) {
+        // NBD replies don't include the IO size so we'll have to keep
+        // this data around.
+        AbortSubmittedRequests(Device);
+    }
+    else {
+        DrainDeviceQueue(Device, TRUE);
+    }
 
     WnbdReleaseDevice(Device);
     SrbStatus = SRB_STATUS_SUCCESS;

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -281,7 +281,7 @@ NTSTATUS WnbdHandleResponse(
     }
     KeReleaseSpinLock(&Device->SubmittedReqListLock, Irql);
     if (!Element) {
-        WNBD_LOG_ERROR("Received reply with no matching request tag: 0x%llx",
+        WNBD_LOG_LOUD("Received reply with no matching request tag: 0x%llx",
             Response->RequestHandle);
         return STATUS_NOT_FOUND;
     }

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -337,9 +337,11 @@ DWORD WnbdIoctlSendResponse(
 
     if (Status && !(Status == ERROR_IO_PENDING && Overlapped)) {
         LogWarning(
-            "Could not send response. Error: %d. "
-            "Connection id: %llu. Error message: %s",
-            Status, ConnectionId, win32_strerror(Status).c_str());
+            "Could not send response. "
+            "Connection id: %llu. Request id: %llu. "
+            "Error: %d. Error message: %s",
+            ConnectionId, Response->RequestHandle,
+            Status, win32_strerror(Status).c_str());
     }
 
     return Status;


### PR DESCRIPTION
When hitting timeouts, Storport resets the adapter. NBD replies
don't include the IO size so we keep that information around
when resetting the adapter. We don't need the payload itself,
just the size so that we can tell where the next NBD header
starts.

We don't have to do this for the IOCTL based IO channel, in
which case we're going to clean up the IO queue.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>