### PR TITLE
Disable static code analysis on wnbd-client project

### DIFF
--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -154,4 +154,7 @@
     <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets" Condition="Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" />
   </ImportGroup>
+  <PropertyGroup>
+    <CAExcludePath>$(SolutionDir)\deps;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Running code analysis on wnbd-client project will also include the boost
source code.

This patch disables the static code analysis on the third party libraries
to reduce the verbosity on the build log:
https://ci.appveyor.com/project/aserdean/wnbd/builds/35959630/job/oj6tg32upx01n8j7#L742

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>