### PR TITLE
Fix compilation issues VS 2017

### DIFF
--- a/driver/options.c
+++ b/driver/options.c
@@ -9,6 +9,9 @@
 #include "util.h"
 #include "wnbd_ioctl.h"
 
+#pragma warning(push)
+#pragma warning(disable:4204)
+
 extern UNICODE_STRING GlobalRegistryPath;
 
 #define WNBD_DEF_OPT(OptName, TypeSuffix, DefaultVal) \
@@ -303,3 +306,5 @@ WnbdListDrvOpt(
 
     return STATUS_SUCCESS;
 }
+
+#pragma warning(pop)


### PR DESCRIPTION
MSVC 2017 complains:
Warning	C4204	nonstandard extension used: non-constant aggregate initializer	driver	driver\options.c	84
Warning	C4204	nonstandard extension used: non-constant aggregate initializer	driver	driver\options.c	153
Warning	C4204	nonstandard extension used: non-constant aggregate initializer	driver	driver\options.c	154
(the above also applies on nonupdated VS 2019)
For reference:
https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/6b73z23c(v=vs.90)

Such type of initializations are useful and we disable the warning since it can
be safely ignored.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>