### PR TITLE
Add command line options to install and uninstall the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,31 +121,18 @@ Those steps are not required when using a certified driver.
 
 ### Install / Uninstall
 
-We require the [devcon.exe](https://cloudbase.it/downloads/devcon.exe) utility in order to
-install and uninstall the driver.
+You can use the `wnbd-client.exe` command line argument to install and remove the driver.
 
-To **install** the driver, issue the following from an elevated command prompt:
-
-```PowerShell
-.\devcon.exe install .\wnbd.inf root\wnbd
+To ***install*** the driver, issue the following from an elevated PowerShell prompt:
+```Powershell
+.\wnbd-client.exe install-driver .\wnbd.inf
 ```
 
-(The command above assumes that the utility `devcon.exe` and the driver files `wnbd.inf`, `wnbd.cat`, `wnbd.sys` are in the current directory)
-
-After installing the driver, copy ``libwnbd.dll`` and ``wnbd-client.exe``,
-also adding the destination folder to the environment PATH variable.
-
-To **uninstall** the driver, issue the following from an elevated PowerShell prompt:
-
-```PowerShell
-.\devcon.exe remove "root\wnbd"
-pnputil.exe /enum-drivers | sls -Context 5 wnbd | findstr Published | `
-    % {$_ -match "(oem\d+.inf)"; pnputil.exe /delete-driver $matches[0] /force }
+To ***uninstall*** the driver, issue the following from an elevated PowerShell prompt:
+```Powershell
+.\wnbd-client.exe uninstall-driver
 ```
-
-(The command above assumes that the utility `devcon.exe` is in the current directory)
-
-For convenience, we included [reinstall.ps1](vstudio/reinstall.ps1), which installs/reinstalls the driver.
+The `uninstall-driver` will soft disconnect any existing mappings, remove any registered device drivers and remove any prior installation of the driver.
 
 After installing the driver, you may want to copy ``wnbd-client.exe`` and ``libwnbd.dll``
 to a directory that's part of the ``PATH`` environment variable.

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -9,6 +9,7 @@
 
 #include <windows.h>
 #include <cfgmgr32.h>
+#include <SetupAPI.h>
 
 #include "wnbd_ioctl.h"
 
@@ -21,6 +22,9 @@ extern "C" {
 #define WNBD_LOG_MESSAGE_MAX_SIZE 4096
 #define WNBD_DEFAULT_RM_TIMEOUT_MS 30 * 1000
 #define WNBD_DEFAULT_RM_RETRY_INTERVAL_MS 2000
+
+#define WNBD_HARDWAREID "root\\wnbd"
+#define WNBD_HARDWAREID_LEN sizeof(WNBD_HARDWAREID)
 
 typedef enum
 {
@@ -272,6 +276,8 @@ DWORD WnbdOpenAdapter(PHANDLE Handle);
 DWORD WnbdOpenAdapterEx(PHANDLE Handle, PDEVINST CMDeviceInstance);
 DWORD WnbdOpenAdapterCMDeviceInstance(PDEVINST DeviceInstance);
 DWORD WnbdIoctlPing(HANDLE Adapter, LPOVERLAPPED Overlapped);
+DWORD WnbdUninstallDriver(PBOOL RebootRequired);
+DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired);
 
 // The "Overlapped" parameter used by WnbdIoctl* functions allows
 // asynchronous calls. If NULL, a valid overlapped structure is

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -28,10 +28,12 @@ EXPORTS
     WnbdSetDrvOpt
     WnbdResetDrvOpt
     WnbdListDrvOpt
-
+    WnbdInstallDriver
+    WnbdUninstallDriver
     WnbdOpenAdapter
     WnbdOpenAdapterEx
     WnbdOpenAdapterCMDeviceInstance
+
     WnbdIoctlPing
     WnbdIoctlCreate
     WnbdIoctlRemove

--- a/vstudio/reinstall.ps1
+++ b/vstudio/reinstall.ps1
@@ -1,21 +1,18 @@
 $scriptLocation = [System.IO.Path]::GetDirectoryName(
     $myInvocation.MyCommand.Definition)
 
-$devconBin = "$scriptLocation\devcon.exe"
+$wnbdBin = "$scriptLocation\wnbd-client.exe"
 $wnbdInf = "$scriptLocation\wnbd.inf"
 $wnbdCat = "$scriptLocation\wnbd.cat"
 $wnbdSys = "$scriptLocation\wnbd.sys"
 
-$requiredFiles = @($devconBin, $wnbdInf, $wnbdCat, $wnbdSys)
+$requiredFiles = @($wnbdBin, $wnbdInf, $wnbdCat, $wnbdSys)
 foreach ($path in $requiredFiles) {
     if (!(Test-Path -Path $path -PathType leaf)) {
         Write-Warning "Could not find file: $path"
     }
 }
 
-& $devconBin remove "root\wnbd"
+& $wnbdBin uninstall-driver
 
-pnputil.exe /enum-drivers | sls -Context 5 wnbd | findstr Published | `
-    % {$_ -match "(oem\d+.inf)"; pnputil.exe /delete-driver $matches[0] /force }
-
-& $devconBin install $wnbdInf root\wnbd
+& $wnbdBin install-driver $wnbdInf

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -316,6 +316,26 @@ DWORD execute_reset_opt(const po::variables_map& vm)
         safe_get_param<bool>(vm, "persistent"));
 }
 
+DWORD execute_install(const po::variables_map& vm)
+{
+    return CmdInstall(
+        safe_get_param<string>(vm, "filename").c_str());
+}
+
+void get_install_args(
+    po::positional_options_description& positonal_opts,
+    po::options_description& named_opts)
+{
+    positonal_opts.add("filename", 1);
+    named_opts.add_options()
+        ("filename", po::value<string>()->required(), "The OEM driver information (wnbd.inf) path");
+}
+
+DWORD execute_clean_uninstall(const po::variables_map& vm)
+{
+    return CmdUninstall();
+}
+
 Client::Command commands[] = {
     Client::Command(
         "version", {"-v"}, "Get the client, library and driver version.",
@@ -352,4 +372,11 @@ Client::Command commands[] = {
     Client::Command(
         "reset-opt", {}, "Reset driver option.",
         execute_reset_opt, get_reset_opt_args),
+    Client::Command(
+        "install-driver", {}, "Install WNBD driver and create its adapter",
+        execute_install, get_install_args),
+    Client::Command(
+        "uninstall-driver", {}, "Hard remove all disk mappings and adapters"
+                                " and uninstall all WNBD driver instances",
+        execute_clean_uninstall),
 };

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -412,3 +412,29 @@ CmdListOpt(BOOLEAN Persistent)
     free(OptList);
     return 0;
 }
+
+DWORD
+CmdUninstall()
+{
+    BOOL RebootRequired = FALSE;
+    DWORD Status = WnbdUninstallDriver(&RebootRequired);
+    if (RebootRequired) {
+        cerr << "Reboot required to complete the cleanup process"
+             << endl;
+    }
+
+    return Status;
+}
+
+DWORD
+CmdInstall(std::string FileName)
+{
+    BOOL RebootRequired = FALSE;
+    DWORD Status = WnbdInstallDriver(FileName.c_str(), &RebootRequired);
+    if (RebootRequired) {
+        cerr << "Reboot required to complete the installation"
+             << endl;
+    }
+
+    return Status;
+}

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -69,3 +69,9 @@ CmdResetOpt(std::string Name, BOOLEAN Persistent);
 
 DWORD
 CmdListOpt(BOOLEAN Persistent);
+
+DWORD
+CmdUninstall();
+
+DWORD
+CmdInstall(std::string FileName);


### PR DESCRIPTION
This patch introduces two more supported CLI commands.
`install-driver`, `clean-uninstall`.

The hardware ID and length are predefined, the only required installation
argument is the INF file location.

The clean uninstall sequence will remove any created devices and it will
also try to remove any previous driver installations by  cycling through
all the OEM driver installations and trying to find a match over
the catalog file `wnbd.cat`.

Invoking the clean uninstall will also hard disconnect any online mappings.

Document the usage of the client utility `wnbd-client` to install
and clean uninstall the driver.