### PR TITLE
Clean log messages

### DIFF
--- a/driver/debug.h
+++ b/driver/debug.h
@@ -12,9 +12,8 @@
 
 #define WNBD_LVL_ERROR    DPFLTR_ERROR_LEVEL
 #define WNBD_LVL_WARN     DPFLTR_WARNING_LEVEL
-#define WNBD_LVL_TRACE    DPFLTR_TRACE_LEVEL
 #define WNBD_LVL_INFO     DPFLTR_INFO_LEVEL
-#define WNBD_LVL_LOUD     (DPFLTR_INFO_LEVEL + 1)
+#define WNBD_LVL_DEBUG     (DPFLTR_INFO_LEVEL + 1)
 
 VOID
 WnbdLog(_In_ UINT32 Level,
@@ -22,14 +21,11 @@ WnbdLog(_In_ UINT32 Level,
         _In_ UINT32 Line,
         _In_ PCHAR Format, ...);
 
-#define WNBD_LOG_LOUD(_format, ...) \
-   WnbdLog(WNBD_LVL_LOUD, __FUNCTION__, __LINE__, _format,  __VA_ARGS__)
+#define WNBD_LOG_DEBUG(_format, ...) \
+   WnbdLog(WNBD_LVL_DEBUG, __FUNCTION__, __LINE__, _format,  __VA_ARGS__)
 
 #define WNBD_LOG_INFO(_format, ...) \
    WnbdLog(WNBD_LVL_INFO, __FUNCTION__, __LINE__, _format, __VA_ARGS__)
-
-#define WNBD_LOG_TRACE(_format, ...) \
-   WnbdLog(WNBD_LVL_TRACE, __FUNCTION__, __LINE__, _format, __VA_ARGS__)
 
 #define WNBD_LOG_ERROR(_format, ...) \
    WnbdLog(WNBD_LVL_ERROR, __FUNCTION__, __LINE__, _format, __VA_ARGS__)

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -119,8 +119,8 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
     ASSERT(IoLocation);
     UCHAR MinorFunction = IoLocation->MinorFunction;
 
-    WNBD_LOG_LOUD("Received PnP request: %s (%d).",
-                  WnbdToStringPnpMinorFunction(MinorFunction), MinorFunction);
+    WNBD_LOG_DEBUG("Received PnP request: %s (%d).",
+                   WnbdToStringPnpMinorFunction(MinorFunction), MinorFunction);
     switch (MinorFunction) {
     case IRP_MN_QUERY_CAPABILITIES:
         IoLocation->Parameters.DeviceCapabilities.Capabilities->SilentInstall = 1;
@@ -161,7 +161,7 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
 
     Status = StorPortDispatchPnp(DeviceObject, Irp);
 
-    WNBD_LOG_LOUD("Exit: 0x%x", Status);
+    WNBD_LOG_DEBUG("Exit: 0x%x", Status);
     return Status;
 }
 

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -29,8 +29,6 @@ NTSTATUS
 DriverEntry(PDRIVER_OBJECT DriverObject,
             PUNICODE_STRING RegistryPath)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     /*
      * Register Virtual Storport Miniport data
      */
@@ -103,8 +101,6 @@ DriverEntry(PDRIVER_OBJECT DriverObject,
     DriverObject->MajorFunction[IRP_MJ_PNP] = 0 != StorPortDispatchPnp ? WnbdDispatchPnp : 0;
     GlobalExt = NULL;
 
-    WNBD_LOG_LOUD(": Exit");
-
     /*
      * Report status in upper layers
      */
@@ -116,7 +112,6 @@ NTSTATUS
 WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
                 PIRP Irp)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Irp);
     NTSTATUS Status = STATUS_INVALID_DEVICE_REQUEST;
     PIO_STACK_LOCATION IoLocation = IoGetCurrentIrpStackLocation(Irp);
@@ -146,7 +141,7 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
             }
             Status = WnbdGetScsiAddress(DeviceObject, &ScsiAddress);
             if (Status) {
-                WNBD_LOG_ERROR("Could not query SCSI address. Error: %d.", Status);
+                WNBD_LOG_WARN("Could not query SCSI address. Error: 0x%x.", Status);
                 break;
             }
 
@@ -166,7 +161,7 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
 
     Status = StorPortDispatchPnp(DeviceObject, Irp);
 
-    WNBD_LOG_LOUD(": Exit: %d", Status);
+    WNBD_LOG_LOUD("Exit: 0x%x", Status);
     return Status;
 }
 
@@ -174,11 +169,8 @@ _Use_decl_annotations_
 VOID
 WnbdDriverUnload(PDRIVER_OBJECT DriverObject)
 {
-    WNBD_LOG_LOUD(": Enter");
 
     if (0 != StorPortDriverUnload) {
         StorPortDriverUnload(DriverObject);
     }
-
-    WNBD_LOG_LOUD(": Exit");
 }

--- a/driver/nbd_dispatch.c
+++ b/driver/nbd_dispatch.c
@@ -111,9 +111,9 @@ WnbdProcessDeviceThreadRequests(_In_ PWNBD_DISK_DEVICE Device)
             ExInterlockedInsertTailList(
                 &Device->SubmittedReqListHead,
                 &Element->Link, &Device->SubmittedReqListLock);
-            WNBD_LOG_LOUD("Sending %s request. Address: %p Tag: 0x%llx. FUA: %d",
-                          NbdRequestTypeStr(NbdReqType), Element->Srb, Element->Tag,
-                          Element->FUA);
+            WNBD_LOG_DEBUG("Sending %s request. Address: %p Tag: 0x%llx. FUA: %d",
+                           NbdRequestTypeStr(NbdReqType), Element->Srb, Element->Tag,
+                           Element->FUA);
 
             if(NbdReqType == NBD_CMD_WRITE){
                 Status = WnbdRequestWrite(Device, Element,
@@ -236,8 +236,8 @@ NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device)
         // We need to avoid accessing aborted or already completed SRBs.
         PCDB Cdb = (PCDB)&Element->Srb->Cdb;
         int NbdReqType = ScsiOpToNbdReqType(Cdb->AsByte[0]);
-        WNBD_LOG_LOUD("Received reply header for %s %p 0x%llx.",
-                      NbdRequestTypeStr(NbdReqType), Element->Srb, Element->Tag);
+        WNBD_LOG_DEBUG("Received reply header for %s %p 0x%llx.",
+                       NbdRequestTypeStr(NbdReqType), Element->Srb, Element->Tag);
 
         if(IsReadSrb(Element->Srb)) {
             StorResult = StorPortGetSystemAddress(Element->DeviceExtension, Element->Srb, &SrbBuff);
@@ -304,8 +304,8 @@ NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device)
         InterlockedIncrement64(&Device->Stats.CompletedAbortedIORequests);
     }
     else {
-        WNBD_LOG_LOUD("Successfully completed request %p 0x%llx.",
-                      Element->Srb, Element->Tag);
+        WNBD_LOG_DEBUG("Successfully completed request %p 0x%llx.",
+                       Element->Srb, Element->Tag);
     }
 
 Exit:

--- a/driver/options.c
+++ b/driver/options.c
@@ -67,7 +67,7 @@ ReadRegistryValue(
         RTL_REGISTRY_ABSOLUTE | RTL_REGISTRY_OPTIONAL,
         GlobalRegistryPath.Buffer, Table, 0, 0);
 
-    WNBD_LOG_LOUD(": Exit: %d", Status);
+    WNBD_LOG_LOUD("Exit: 0x%x", Status);
     return Status;
 }
 
@@ -249,14 +249,14 @@ NTSTATUS WnbdReloadPersistentOptions()
         Status = WnbdGetPersistentOpt(Option->Name, &PersistentValue);
         if (Status) {
             if (Status != STATUS_OBJECT_NAME_NOT_FOUND) {
-                WNBD_LOG_WARN("Could not load option %ls. Error: %d",
+                WNBD_LOG_WARN("Could not load option %ls. Error: 0x%x",
                               Option->Name, Status);
             }
             continue;
         }
         Status = WnbdProcessOptionValue(Option, &PersistentValue);
         if (Status) {
-            WNBD_LOG_WARN("Could not process option %ls. Error: %d",
+            WNBD_LOG_WARN("Could not process option %ls. Error: 0x%x",
                           Option->Name, Status);
             continue;
         }

--- a/driver/options.c
+++ b/driver/options.c
@@ -67,7 +67,7 @@ ReadRegistryValue(
         RTL_REGISTRY_ABSOLUTE | RTL_REGISTRY_OPTIONAL,
         GlobalRegistryPath.Buffer, Table, 0, 0);
 
-    WNBD_LOG_LOUD("Exit: 0x%x", Status);
+    WNBD_LOG_DEBUG("Exit: 0x%x", Status);
     return Status;
 }
 

--- a/driver/scsi_driver_extensions.c
+++ b/driver/scsi_driver_extensions.c
@@ -138,14 +138,14 @@ WnbdHwFindAdapter(PVOID DeviceExtension,
         goto Exit;
     }
 
-    WNBD_LOG_LOUD("Exit SP_RETURN_FOUND");
+    WNBD_LOG_DEBUG("Exit SP_RETURN_FOUND");
     return SP_RETURN_FOUND;
 Exit:
     RtlFreeUnicodeString(&Ext->DeviceInterface);
 CleanLock:
     ExDeleteResourceLite(&Ext->DeviceCreationLock);
 Clean:
-    WNBD_LOG_LOUD("Exit SP_RETURN_NOT_FOUND");
+    WNBD_LOG_DEBUG("Exit SP_RETURN_NOT_FOUND");
     return SP_RETURN_NOT_FOUND;
 }
 
@@ -205,10 +205,10 @@ WnbdHwProcessServiceRequest(PVOID DeviceExtension,
 
     if (STATUS_PENDING != Status) {
         ((PIRP)Irp)->IoStatus.Status = Status;
-        WNBD_LOG_LOUD("Calling StorPortCompleteServiceIrp");
+        WNBD_LOG_DEBUG("Calling StorPortCompleteServiceIrp");
         StorPortCompleteServiceIrp(DeviceExtension, Irp);
     } else {
-        WNBD_LOG_LOUD("Pending HwProcessServiceRequest");
+        WNBD_LOG_DEBUG("Pending HwProcessServiceRequest");
     }
 }
 
@@ -424,10 +424,10 @@ WnbdHwStartIo(PVOID DeviceExtension,
      * If the operation is not pending notify the Storport of completion
      */
     if (Complete) {
-        WNBD_LOG_LOUD("RequestComplete of %s status: 0x%x(%s)",
-                      WnbdToStringSrbFunction(Srb->Function),
-                      SrbStatus,
-                      WnbdToStringSrbStatus(SrbStatus));
+        WNBD_LOG_DEBUG("RequestComplete of %s status: 0x%x(%s)",
+                       WnbdToStringSrbFunction(Srb->Function),
+                       SrbStatus,
+                       WnbdToStringSrbStatus(SrbStatus));
         Srb->SrbStatus = SrbStatus;
         StorPortNotification(RequestComplete, DeviceExtension, Srb);
     }

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -18,7 +18,6 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
                         PSCSI_REQUEST_BLOCK Srb)
 
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
@@ -28,7 +27,7 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
     if (SrbGetCdb(Srb)) {
         BYTE CdbValue = SrbGetCdb(Srb)->AsByte[0];
 
-        WNBD_LOG_INFO(": Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
+        WNBD_LOG_INFO("Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
             CdbValue, Srb, CdbValue, Srb->PathId, Srb->TargetId, Srb->Lun);
     }
 
@@ -54,7 +53,6 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
     SrbStatus = SRB_STATUS_SUCCESS;
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
     return SrbStatus;
 }
 
@@ -63,14 +61,10 @@ UCHAR
 WnbdAbortFunction(_In_ PVOID DeviceExtension,
                   _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
     UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
-
-    WNBD_LOG_LOUD(": Exit");
 
     return SrbStatus;
 }
@@ -80,14 +74,10 @@ UCHAR
 WnbdResetLogicalUnitFunction(PVOID DeviceExtension,
                              PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
     UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
-
-    WNBD_LOG_LOUD(": Exit");
 
     return SrbStatus;
 }
@@ -97,8 +87,6 @@ UCHAR
 WnbdResetDeviceFunction(PVOID DeviceExtension,
                         PSCSI_REQUEST_BLOCK  Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
@@ -107,8 +95,6 @@ WnbdResetDeviceFunction(PVOID DeviceExtension,
                             Srb->TargetId,
                             SP_UNTAGGED,
                             SRB_STATUS_TIMEOUT);
-
-    WNBD_LOG_LOUD(": Exit");
 
     return SRB_STATUS_SUCCESS;
 }
@@ -119,8 +105,6 @@ WnbdExecuteScsiFunction(PVOID DeviceExtension,
                         PSCSI_REQUEST_BLOCK Srb,
                         PBOOLEAN Complete)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     ASSERT(DeviceExtension);
     ASSERT(Srb);
     ASSERT(Complete);
@@ -133,7 +117,7 @@ WnbdExecuteScsiFunction(PVOID DeviceExtension,
     if (SrbGetCdb(Srb)) {
         BYTE CdbValue = SrbGetCdb(Srb)->AsByte[0];
 
-        WNBD_LOG_INFO(": Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
+        WNBD_LOG_LOUD("Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
             CdbValue, Srb, CdbValue, Srb->PathId, Srb->TargetId, Srb->Lun);
     }
 
@@ -165,7 +149,6 @@ Exit:
     if (Device)
         WnbdReleaseDevice(Device);
 
-    WNBD_LOG_LOUD(": Exit");
     return SrbStatus;
 }
 
@@ -173,8 +156,6 @@ _Use_decl_annotations_
 UCHAR
 WnbdPNPFunction(PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     ASSERT(Srb);
     PSCSI_PNP_REQUEST_BLOCK PNP = (PSCSI_PNP_REQUEST_BLOCK) Srb;
     UCHAR SrbStatus = SRB_STATUS_INVALID_REQUEST;
@@ -208,7 +189,7 @@ WnbdPNPFunction(PSCSI_REQUEST_BLOCK Srb)
         break;
     }
 
-    WNBD_LOG_LOUD(": Exit with SrbStatus: %s",
+    WNBD_LOG_LOUD("Exit with SrbStatus: %s",
                   WnbdToStringSrbStatus(SrbStatus));
 
     return SrbStatus;

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -117,7 +117,7 @@ WnbdExecuteScsiFunction(PVOID DeviceExtension,
     if (SrbGetCdb(Srb)) {
         BYTE CdbValue = SrbGetCdb(Srb)->AsByte[0];
 
-        WNBD_LOG_LOUD("Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
+        WNBD_LOG_DEBUG("Received %#02x command. SRB = 0x%p. CDB = 0x%x. PathId: %d TargetId: %d LUN: %d",
             CdbValue, Srb, CdbValue, Srb->PathId, Srb->TargetId, Srb->Lun);
     }
 
@@ -189,8 +189,8 @@ WnbdPNPFunction(PSCSI_REQUEST_BLOCK Srb)
         break;
     }
 
-    WNBD_LOG_LOUD("Exit with SrbStatus: %s",
-                  WnbdToStringSrbStatus(SrbStatus));
+    WNBD_LOG_DEBUG("Exit with SrbStatus: %s",
+                   WnbdToStringSrbStatus(SrbStatus));
 
     return SrbStatus;
 }

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -20,7 +20,6 @@ WnbdReadCapacity(_In_ PWNBD_DISK_DEVICE Device,
                  _In_ UINT BlockSize,
                  _In_ UINT64 BlockCount)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Srb);
     ASSERT(Cdb);
     WNBD_LOG_INFO("Using BlockSize: %u, BlockCount: %llu", BlockSize, BlockCount);
@@ -95,13 +94,11 @@ WnbdReadCapacity(_In_ PWNBD_DISK_DEVICE Device,
         }
         break;
     default:
-        WNBD_LOG_ERROR("Unknown read capacity operation: %u", Cdb->CDB10.OperationCode);
+        WNBD_LOG_INFO("Unknown read capacity operation: %u", Cdb->CDB10.OperationCode);
         break;
     }
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
-
     return SrbStatus;
 }
 
@@ -110,7 +107,6 @@ WnbdSetVpdSupportedPages(_In_ PVOID Data,
                          _In_ UCHAR NumberOfSupportedPages,
                          _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Data);
     ASSERT(Srb);
 
@@ -129,7 +125,6 @@ WnbdSetVpdSupportedPages(_In_ PVOID Data,
 
     SrbSetDataTransferLength(Srb, sizeof(VPD_SUPPORTED_PAGES_PAGE) + NumberOfSupportedPages);
 
-    WNBD_LOG_LOUD(": Exit");
     return SRB_STATUS_SUCCESS;
 }
 
@@ -138,7 +133,6 @@ WnbdSetVpdSerialNumber(_In_ PVOID Data,
                        _In_ PCHAR DeviceSerial,
                        _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Data);
     ASSERT(Srb);
 
@@ -155,7 +149,6 @@ WnbdSetVpdSerialNumber(_In_ PVOID Data,
 
     SrbSetDataTransferLength(Srb, sizeof(VPD_SERIAL_NUMBER_PAGE) + Size);
 
-    WNBD_LOG_LOUD(": Exit");
     return SRB_STATUS_SUCCESS;
 }
 
@@ -165,7 +158,6 @@ WnbdSetVpdBlockLimits(_In_ PVOID Data,
                       _In_ PSCSI_REQUEST_BLOCK Srb,
                       _In_ UINT32 MaximumTransferLength)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Data);
     ASSERT(Srb);
 
@@ -192,8 +184,6 @@ WnbdSetVpdBlockLimits(_In_ PVOID Data,
     }
 
     SrbSetDataTransferLength(Srb, sizeof(VPD_BLOCK_LIMITS_PAGE));
-
-    WNBD_LOG_LOUD(": Exit");
 }
 
 VOID
@@ -202,8 +192,6 @@ WnbdSetVpdLogicalBlockProvisioning(
     _In_ PWNBD_DISK_DEVICE Device,
     _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     PVPD_LOGICAL_BLOCK_PROVISIONING_PAGE LogicalBlockProvisioning = Data;
     LogicalBlockProvisioning->DeviceType = DIRECT_ACCESS_DEVICE;
     LogicalBlockProvisioning->DeviceTypeQualifier = DEVICE_QUALIFIER_ACTIVE;
@@ -219,8 +207,6 @@ WnbdSetVpdLogicalBlockProvisioning(
     }
 
     SrbSetDataTransferLength(Srb, sizeof(VPD_LOGICAL_BLOCK_PROVISIONING_PAGE));
-
-    WNBD_LOG_LOUD(": Exit");
 }
 
 VOID
@@ -229,8 +215,6 @@ WnbdSetVpdBlockDeviceCharacteristics(
     _In_ PWNBD_DISK_DEVICE Device,
     _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     PVPD_BLOCK_DEVICE_CHARACTERISTICS_PAGE CharacteristicsPage = Data;
 
     CharacteristicsPage->DeviceType = DIRECT_ACCESS_DEVICE;
@@ -243,8 +227,6 @@ WnbdSetVpdBlockDeviceCharacteristics(
     CharacteristicsPage->FUAB = !!Device->Properties.Flags.FUASupported;
 
     SrbSetDataTransferLength(Srb, sizeof(VPD_BLOCK_DEVICE_CHARACTERISTICS_PAGE));
-
-    WNBD_LOG_LOUD(": Exit");
 }
 
 UCHAR
@@ -254,7 +236,6 @@ WnbdProcessExtendedInquiry(_In_ PVOID Data,
                            _In_ PCDB Cdb,
                            _In_ PWNBD_DISK_DEVICE Device)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Data);
     ASSERT(Srb);
     ASSERT(Cdb);
@@ -303,12 +284,11 @@ WnbdProcessExtendedInquiry(_In_ PVOID Data,
         WnbdSetVpdBlockDeviceCharacteristics(Data, Device, Srb);
         break;
     default:
-        WNBD_LOG_ERROR("Unknown VPD Page: %u", Cdb->CDB6INQUIRY3.PageCode);
+        WNBD_LOG_INFO("Unknown VPD Page: %u", Cdb->CDB6INQUIRY3.PageCode);
         break;
     }
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
     return SrbStatus;
 }
 
@@ -317,7 +297,6 @@ WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
             _In_ PSCSI_REQUEST_BLOCK Srb,
             _In_ PCDB Cdb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Srb);
     ASSERT(Cdb);
 
@@ -334,7 +313,7 @@ WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
 
     switch (Cdb->CDB6INQUIRY3.EnableVitalProductData) {
     case 0:
-        WNBD_LOG_INFO("Normal Inquiry");
+        WNBD_LOG_LOUD("Normal Inquiry");
         if (0 != Cdb->CDB6INQUIRY3.PageCode) {
             SrbStatus = SRB_STATUS_INTERNAL_ERROR;
             goto Exit;
@@ -345,13 +324,12 @@ WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
         SrbStatus = SRB_STATUS_SUCCESS;
         break;
     default:
-        WNBD_LOG_INFO("Extended Inquiry");
+        WNBD_LOG_LOUD("Extended Inquiry");
         SrbStatus = WnbdProcessExtendedInquiry(DataBuffer, DataTransferLength, Srb, Cdb, Device);
         break;
     }
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
     return SrbStatus;
 }
 
@@ -364,7 +342,6 @@ WnbdSetModeSense(_In_ PVOID Data,
                  _Out_ PVOID* Page,
                  _Out_ PULONG Length)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Cdb);
     ASSERT(Data);
 
@@ -382,7 +359,7 @@ WnbdSetModeSense(_In_ PVOID Data,
             goto Exit;
         }
         if(*Length > MaxLength) {
-            WNBD_LOG_ERROR("MODE_SENSE overrun: %d > %d", *Length, MaxLength);
+            WNBD_LOG_WARN("MODE_SENSE overrun: %d > %d", *Length, MaxLength);
             SrbStatus = SRB_STATUS_DATA_OVERRUN;
             goto Exit;
         }
@@ -408,7 +385,7 @@ WnbdSetModeSense(_In_ PVOID Data,
             goto Exit;
         }
         if(*Length > MaxLength) {
-            WNBD_LOG_ERROR("MODE_SENSE overrun: %d > %d", *Length, MaxLength);
+            WNBD_LOG_WARN("MODE_SENSE overrun: %d > %d", *Length, MaxLength);
             SrbStatus = SRB_STATUS_DATA_OVERRUN;
             goto Exit;
         }
@@ -428,13 +405,13 @@ WnbdSetModeSense(_In_ PVOID Data,
         }
         break;
     default:
-        WNBD_LOG_ERROR("Unknown MODE_SENSE byte: %u", Cdb->AsByte[0]);
+        WNBD_LOG_INFO("Unknown MODE_SENSE byte: %u", Cdb->AsByte[0]);
         SrbStatus = SRB_STATUS_INVALID_REQUEST;
         break;
     }
 
 Exit:
-    WNBD_LOG_LOUD(": Exit: %#02x", SrbStatus);
+    WNBD_LOG_LOUD("Exit: %#02x", SrbStatus);
     return SrbStatus;
 }
 
@@ -443,7 +420,6 @@ WnbdModeSense(_In_ PWNBD_DISK_DEVICE Device,
               _In_ PSCSI_REQUEST_BLOCK Srb,
               _In_ PCDB Cdb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Srb);
     ASSERT(Cdb);
 
@@ -464,7 +440,7 @@ WnbdModeSense(_In_ PWNBD_DISK_DEVICE Device,
         !!Device->Properties.Flags.FUASupported,
         &Page, &Length);
     if (SRB_STATUS_SUCCESS != SrbStatus || NULL == Page) {
-        WNBD_LOG_ERROR("Could not set mode sense.");
+        WNBD_LOG_INFO("Could not set mode sense.");
         goto Exit;
     }
 
@@ -478,7 +454,6 @@ WnbdModeSense(_In_ PWNBD_DISK_DEVICE Device,
     SrbSetDataTransferLength(Srb, Length);
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
     return SrbStatus;
 }
 
@@ -490,7 +465,6 @@ WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
                 _In_ UINT64 DataLength,
                 _In_ BOOLEAN FUA)
 {
-    WNBD_LOG_LOUD(": Enter");
     NTSTATUS Status = STATUS_SUCCESS;
 
     InterlockedIncrement64(&Device->Stats.TotalReceivedIORequests);
@@ -516,7 +490,6 @@ WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
     Status = STATUS_PENDING;
 
 Exit:
-    WNBD_LOG_LOUD(": Exit");
     return Status;
 }
 
@@ -525,7 +498,6 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
                   _In_ PWNBD_DISK_DEVICE Device,
                   _In_ PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceExtension);
     ASSERT(Device);
     ASSERT(Srb);
@@ -553,7 +525,7 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
         DataLength = BlockCount * Device->Properties.BlockSize;
         if (DataLength < Srb->DataTransferLength &&
             (Cdb->AsByte[0] != SCSIOP_SYNCHRONIZE_CACHE || Cdb->AsByte[0] != SCSIOP_SYNCHRONIZE_CACHE16)) {
-            WNBD_LOG_ERROR("STATUS_BUFFER_TOO_SMALL");
+            WNBD_LOG_WARN("Requested length is less than the SRB data length");
             Srb->SrbStatus = SRB_STATUS_ABORTED;
             Status = STATUS_BUFFER_TOO_SMALL;
             break;
@@ -583,7 +555,7 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
         // We don't support the anchored state at the moment.
         if (Cdb->UNMAP.Anchor)
         {
-            WNBD_LOG_ERROR("Unmap 'anchor' state not supported.");
+            WNBD_LOG_WARN("Unmap 'anchor' state not supported.");
             Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
             Status = STATUS_INVALID_PARAMETER;
             break;
@@ -600,7 +572,7 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
         UINT32 DescriptorCount = BlockDescLength / sizeof(UNMAP_BLOCK_DESCRIPTOR);
         if (DescriptorCount != 1) {
             // Storport should honor the VPD limits.
-            WNBD_LOG_ERROR("Cannot send multiple UNMAP descriptors at a time.");
+            WNBD_LOG_WARN("Cannot send multiple UNMAP descriptors at a time.");
             Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
             Status = STATUS_INVALID_PARAMETER;
             break;
@@ -616,7 +588,7 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
         if (LastBlockAddress < BlockAddress ||
             LastBlockAddress >= Device->Properties.BlockCount)
         {
-            WNBD_LOG_ERROR("Unmap overflow.");
+            WNBD_LOG_WARN("Unmap overflow.");
             Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
             Status = STATUS_INVALID_PARAMETER;
             break;
@@ -629,13 +601,12 @@ WnbdPendOperation(_In_ PWNBD_EXTENSION DeviceExtension,
         }
         break;
     default:
-        WNBD_LOG_ERROR("Unknown Pending SCSI Operation received");
+        WNBD_LOG_INFO("Unknown SCSI operation: %#x", Cdb->AsByte[0]);
         Status = STATUS_INSUFFICIENT_RESOURCES;
         Srb->SrbStatus = SRB_STATUS_ABORTED;
         break;
     }
 
-    WNBD_LOG_LOUD(": Exit");
     return Status;
 }
 
@@ -645,7 +616,6 @@ WnbdHandleSrbOperation(PWNBD_EXTENSION DeviceExtension,
                        PWNBD_DISK_DEVICE Device,
                        PSCSI_REQUEST_BLOCK Srb)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceExtension);
     ASSERT(Device);
     ASSERT(Srb);
@@ -701,6 +671,5 @@ WnbdHandleSrbOperation(PWNBD_EXTENSION DeviceExtension,
         break;
     };
 
-    WNBD_LOG_LOUD(": Exit");
     return status;
 }

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -313,7 +313,7 @@ WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
 
     switch (Cdb->CDB6INQUIRY3.EnableVitalProductData) {
     case 0:
-        WNBD_LOG_LOUD("Normal Inquiry");
+        WNBD_LOG_DEBUG("Normal Inquiry");
         if (0 != Cdb->CDB6INQUIRY3.PageCode) {
             SrbStatus = SRB_STATUS_INTERNAL_ERROR;
             goto Exit;
@@ -324,7 +324,7 @@ WnbdInquiry(_In_ PWNBD_DISK_DEVICE Device,
         SrbStatus = SRB_STATUS_SUCCESS;
         break;
     default:
-        WNBD_LOG_LOUD("Extended Inquiry");
+        WNBD_LOG_DEBUG("Extended Inquiry");
         SrbStatus = WnbdProcessExtendedInquiry(DataBuffer, DataTransferLength, Srb, Cdb, Device);
         break;
     }
@@ -411,7 +411,7 @@ WnbdSetModeSense(_In_ PVOID Data,
     }
 
 Exit:
-    WNBD_LOG_LOUD("Exit: %#02x", SrbStatus);
+    WNBD_LOG_DEBUG("Exit: %#02x", SrbStatus);
     return SrbStatus;
 }
 
@@ -628,7 +628,7 @@ WnbdHandleSrbOperation(PWNBD_EXTENSION DeviceExtension,
     UINT32 BlockSize = Device->Properties.BlockSize;
     UINT64 BlockCount = Device->Properties.BlockCount;
 
-    WNBD_LOG_LOUD("Processing %#02x command", Cdb->AsByte[0]);
+    WNBD_LOG_DEBUG("Processing %#02x command", Cdb->AsByte[0]);
     switch (Cdb->AsByte[0]) {
     case SCSIOP_READ6:
     case SCSIOP_READ:

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -490,9 +490,9 @@ WnbdEnumerateActiveConnections(PWNBD_EXTENSION DeviceExtension, PIRP Irp)
 
     Irp->IoStatus.Information = (OutList->Count * sizeof(WNBD_CONNECTION_INFO)) +
         RTL_SIZEOF_THROUGH_FIELD(WNBD_CONNECTION_LIST, Count);
-    WNBD_LOG_LOUD("Exit: %d. Element count: %d, element size: %d. Total size: %d.",
-                  Status, OutList->Count, OutList->ElementSize,
-                  Irp->IoStatus.Information);
+    WNBD_LOG_DEBUG("Exit: %d. Element count: %d, element size: %d. Total size: %d.",
+                   Status, OutList->Count, OutList->ElementSize,
+                   Irp->IoStatus.Information);
 
     return Status;
 }
@@ -510,7 +510,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
     PWNBD_DISK_DEVICE Device = NULL;
     DWORD Ioctl = IoLocation->Parameters.DeviceIoControl.IoControlCode;
     DWORD OutBuffLength = IoLocation->Parameters.DeviceIoControl.OutputBufferLength;
-    WNBD_LOG_LOUD("DeviceIoControl = 0x%x.", Ioctl);
+    WNBD_LOG_DEBUG("DeviceIoControl = 0x%x.", Ioctl);
 
     if (IOCTL_MINIPORT_PROCESS_SERVICE_IRP != Ioctl) {
         WNBD_LOG_ERROR("Unsupported IOCTL (%x)", Ioctl);
@@ -526,12 +526,12 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
 
     switch (Cmd->IoControlCode) {
     case IOCTL_WNBD_PING:
-        WNBD_LOG_LOUD("IOCTL_WNBD_PING");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_PING");
         Status = STATUS_SUCCESS;
         break;
 
     case IOCTL_WNBD_CREATE:
-        WNBD_LOG_LOUD("IOCTL_WNBD_CREATE");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_CREATE");
         PWNBD_IOCTL_CREATE_COMMAND Command = (
             PWNBD_IOCTL_CREATE_COMMAND) Irp->AssociatedIrp.SystemBuffer;
         if (!Command ||
@@ -594,8 +594,8 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
             RtlCopyMemory(OutInfo, &ConnectionInfo, sizeof(WNBD_CONNECTION_INFO));
             Irp->IoStatus.Information = sizeof(WNBD_CONNECTION_INFO);
 
-            WNBD_LOG_LOUD("Mapped disk. Name: %s, connection id: %llu",
-                          Props.InstanceName, ConnectionInfo.ConnectionId);
+            WNBD_LOG_DEBUG("Mapped disk. Name: %s, connection id: %llu",
+                           Props.InstanceName, ConnectionInfo.ConnectionId);
         }
 
         KeEnterCriticalRegion();
@@ -604,7 +604,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_REMOVE:
-        WNBD_LOG_LOUD("IOCTL_WNBD_REMOVE");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_REMOVE");
         PWNBD_IOCTL_REMOVE_COMMAND RmCmd = (
             PWNBD_IOCTL_REMOVE_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -625,7 +625,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
      case IOCTL_WNBD_LIST:
-        WNBD_LOG_LOUD("IOCTL_WNBD_LIST");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_LIST");
         DWORD RequiredBuffSize = (
             DeviceExtension->DeviceCount * sizeof(WNBD_CONNECTION_INFO))
             + sizeof(WNBD_CONNECTION_LIST);
@@ -633,7 +633,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         if (!Irp->AssociatedIrp.SystemBuffer ||
             CHECK_O_LOCATION_SZ(IoLocation, RequiredBuffSize))
         {
-            WNBD_LOG_LOUD("IOCTL_WNBD_LIST: Bad output buffer");
+            WNBD_LOG_DEBUG("IOCTL_WNBD_LIST: Bad output buffer");
             Irp->IoStatus.Information = RequiredBuffSize;
             break;
         }
@@ -641,7 +641,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_SHOW:
-        WNBD_LOG_LOUD("WNBD_SHOW");
+        WNBD_LOG_DEBUG("WNBD_SHOW");
         PWNBD_IOCTL_SHOW_COMMAND ShowCmd =
             (PWNBD_IOCTL_SHOW_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -689,12 +689,12 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_RELOAD_CONFIG:
-        WNBD_LOG_LOUD("IOCTL_WNBD_RELOAD_CONFIG");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_RELOAD_CONFIG");
         WnbdReloadPersistentOptions();
         break;
 
     case IOCTL_WNBD_STATS:
-        WNBD_LOG_LOUD("WNBD_STATS");
+        WNBD_LOG_DEBUG("WNBD_STATS");
         PWNBD_IOCTL_STATS_COMMAND StatsCmd =
             (PWNBD_IOCTL_STATS_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -737,7 +737,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
 
     case IOCTL_WNBD_FETCH_REQ:
         // TODO: consider moving out individual command handling.
-        WNBD_LOG_LOUD("IOCTL_WNBD_FETCH_REQ");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_FETCH_REQ");
         PWNBD_IOCTL_FETCH_REQ_COMMAND ReqCmd =
             (PWNBD_IOCTL_FETCH_REQ_COMMAND) Irp->AssociatedIrp.SystemBuffer;
         if (!ReqCmd ||
@@ -761,14 +761,14 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
 
         Status = WnbdDispatchRequest(Irp, Device, ReqCmd);
         Irp->IoStatus.Information = sizeof(WNBD_IOCTL_FETCH_REQ_COMMAND);
-        WNBD_LOG_LOUD("Request dispatch status: %d. Request type: %d Request handle: %llx",
-                      Status, ReqCmd->Request.RequestType, ReqCmd->Request.RequestHandle);
+        WNBD_LOG_DEBUG("Request dispatch status: %d. Request type: %d Request handle: %llx",
+                       Status, ReqCmd->Request.RequestType, ReqCmd->Request.RequestHandle);
 
         WnbdReleaseDevice(Device);
         break;
 
     case IOCTL_WNBD_SEND_RSP:
-        WNBD_LOG_LOUD("IOCTL_WNBD_SEND_RSP");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_SEND_RSP");
         PWNBD_IOCTL_SEND_RSP_COMMAND RspCmd =
             (PWNBD_IOCTL_SEND_RSP_COMMAND) Irp->AssociatedIrp.SystemBuffer;
         if (!RspCmd || CHECK_I_LOCATION(IoLocation, PWNBD_IOCTL_FETCH_REQ_COMMAND)) {
@@ -787,13 +787,13 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         }
 
         Status = WnbdHandleResponse(Irp, Device, RspCmd);
-        WNBD_LOG_LOUD("Reply handling status: 0x%x.", Status);
+        WNBD_LOG_DEBUG("Reply handling status: 0x%x.", Status);
 
         WnbdReleaseDevice(Device);
         break;
 
     case IOCTL_WNBD_VERSION:
-        WNBD_LOG_LOUD("IOCTL_WNBD_VERSION");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_VERSION");
         PWNBD_IOCTL_VERSION_COMMAND VersionCmd =
             (PWNBD_IOCTL_VERSION_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -822,7 +822,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_GET_DRV_OPT:
-        WNBD_LOG_LOUD("IOCTL_WNBD_GET_DRV_OPT");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_GET_DRV_OPT");
         PWNBD_IOCTL_GET_DRV_OPT_COMMAND GetOptCmd =
             (PWNBD_IOCTL_GET_DRV_OPT_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -846,7 +846,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_SET_DRV_OPT:
-        WNBD_LOG_LOUD("IOCTL_WNBD_SET_DRV_OPT");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_SET_DRV_OPT");
         PWNBD_IOCTL_SET_DRV_OPT_COMMAND SetOptCmd =
             (PWNBD_IOCTL_SET_DRV_OPT_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -871,7 +871,7 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_RESET_DRV_OPT:
-        WNBD_LOG_LOUD("IOCTL_WNBD_RESET_DRV_OPT");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_RESET_DRV_OPT");
         PWNBD_IOCTL_RESET_DRV_OPT_COMMAND ResetOptCmd =
             (PWNBD_IOCTL_RESET_DRV_OPT_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
@@ -886,12 +886,12 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
 
     case IOCTL_WNBD_LIST_DRV_OPT:
-        WNBD_LOG_LOUD("IOCTL_WNBD_LIST_DRV_OPT");
+        WNBD_LOG_DEBUG("IOCTL_WNBD_LIST_DRV_OPT");
         PWNBD_IOCTL_LIST_DRV_OPT_COMMAND ListOptCmd =
             (PWNBD_IOCTL_LIST_DRV_OPT_COMMAND) Irp->AssociatedIrp.SystemBuffer;
 
         if (!ListOptCmd || CHECK_I_LOCATION(IoLocation, IOCTL_WNBD_LIST_DRV_OPT)) {
-            WNBD_LOG_LOUD("IOCTL_WNBD_RESET_DRV_OPT: Bad input or output buffer");
+            WNBD_LOG_DEBUG("IOCTL_WNBD_RESET_DRV_OPT: Bad input or output buffer");
             Status = STATUS_INVALID_PARAMETER;
             break;
         }
@@ -912,6 +912,6 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         break;
     }
 
-    WNBD_LOG_LOUD("Exit: 0x%x", Status);
+    WNBD_LOG_DEBUG("Exit: 0x%x", Status);
     return Status;
 }

--- a/driver/util.c
+++ b/driver/util.c
@@ -53,8 +53,6 @@ VOID AbortSubmittedRequests(_In_ PWNBD_DISK_DEVICE Device)
     // We're marking submitted requests as aborted and notifying Storport. We only cleaning
     // them up when eventually receiving a reply from the storage backend (needed by NBD,
     // in which case the IO payload is otherwise unknown).
-    WNBD_LOG_LOUD(": Enter");
-
     PLIST_ENTRY ListHead = &Device->SubmittedReqListHead;
     PKSPIN_LOCK ListLock = &Device->SubmittedReqListLock;
 
@@ -317,23 +315,23 @@ ValidateScsiRequest(
     case WnbdReqTypeWrite:
     case WnbdReqTypeFlush:
         if (DevProps->Flags.ReadOnly) {
-            WNBD_LOG_LOUD(
+            WNBD_LOG_DEBUG(
                 "Write, flush or trim requested on a read-only disk.");
             return FALSE;
         }
     case WnbdReqTypeRead:
         break;
     default:
-        WNBD_LOG_LOUD("Unsupported SCSI operation: %d.", ScsiOp);
+        WNBD_LOG_DEBUG("Unsupported SCSI operation: %d.", ScsiOp);
         return FALSE;
     }
 
     if (NbdReqType == WnbdReqTypeUnmap && !DevProps->Flags.UnmapSupported) {
-        WNBD_LOG_LOUD("The NBD server doesn't accept TRIM/UNMAP.");
+        WNBD_LOG_DEBUG("The NBD server doesn't accept TRIM/UNMAP.");
         return FALSE;
     }
     if (NbdReqType == WnbdReqTypeFlush && !DevProps->Flags.FlushSupported) {
-        WNBD_LOG_LOUD("The NBD server doesn't accept flush requests");
+        WNBD_LOG_DEBUG("The NBD server doesn't accept flush requests");
         return FALSE;
     }
 
@@ -378,7 +376,7 @@ VOID CompleteRequest(
     // We must be very careful not to complete the same SRB twice in order
     // to avoid crashes.
     if (!InterlockedExchange8((CHAR*)&Element->Completed, TRUE)) {
-        WNBD_LOG_LOUD(
+        WNBD_LOG_DEBUG(
             "Notifying StorPort of completion of %p 0x%llx status: 0x%x(%s)",
             Element->Srb, Element->Tag, Element->Srb->SrbStatus,
             WnbdToStringSrbStatus(Element->Srb->SrbStatus));

--- a/driver/util.c
+++ b/driver/util.c
@@ -19,8 +19,6 @@
 VOID DrainDeviceQueue(_In_ PWNBD_DISK_DEVICE Device,
                       _In_ BOOLEAN SubmittedRequests)
 {
-    WNBD_LOG_LOUD(": Enter");
-
     PLIST_ENTRY Request;
     PSRB_QUEUE_ELEMENT Element;
     PLIST_ENTRY ListHead;
@@ -81,7 +79,6 @@ VOID AbortSubmittedRequests(_In_ PWNBD_DISK_DEVICE Device)
 VOID
 WnbdCleanupAllDevices(_In_ PWNBD_EXTENSION DeviceExtension)
 {
-    WNBD_LOG_LOUD(": Enter");
     KeSetEvent(&DeviceExtension->GlobalDeviceRemovalEvent, IO_NO_INCREMENT, FALSE);
 
     // The rundown protection is a device reference count. We're going to wait
@@ -90,8 +87,6 @@ WnbdCleanupAllDevices(_In_ PWNBD_EXTENSION DeviceExtension)
 
     KsInitialize();
     KsDestroy();
-
-    WNBD_LOG_LOUD(": Exit");
 }
 
 BOOLEAN
@@ -144,7 +139,6 @@ WnbdFindDeviceByAddr(
     _In_ UCHAR Lun,
     _In_ BOOLEAN Acquire)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceExtension);
 
     KIRQL Irql = { 0 };
@@ -166,7 +160,6 @@ WnbdFindDeviceByAddr(
     }
     KeReleaseSpinLock(&DeviceExtension->DeviceListLock, Irql);
 
-    WNBD_LOG_LOUD(": Exit");
     return Device;
 }
 
@@ -178,7 +171,6 @@ WnbdFindDeviceByConnId(
     _In_ UINT64 ConnectionId,
     _In_ BOOLEAN Acquire)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceExtension);
 
     KIRQL Irql = { 0 };
@@ -197,7 +189,6 @@ WnbdFindDeviceByConnId(
     }
     KeReleaseSpinLock(&DeviceExtension->DeviceListLock, Irql);
 
-    WNBD_LOG_LOUD(": Exit");
     return Device;
 }
 
@@ -209,7 +200,6 @@ WnbdFindDeviceByInstanceName(
     _In_ PCHAR InstanceName,
     _In_ BOOLEAN Acquire)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(DeviceExtension);
 
     KIRQL Irql = { 0 };
@@ -227,8 +217,7 @@ WnbdFindDeviceByInstanceName(
         Device = NULL;
     }
     KeReleaseSpinLock(&DeviceExtension->DeviceListLock, Irql);
-
-    WNBD_LOG_LOUD(": Exit");
+    
     return Device;
 }
 
@@ -269,13 +258,10 @@ VOID DisconnectSocket(_In_ PWNBD_DISK_DEVICE Device) {
 VOID
 WnbdDisconnectAsync(PWNBD_DISK_DEVICE Device)
 {
-    WNBD_LOG_LOUD(": Enter");
     ASSERT(Device);
 
     Device->HardRemoveDevice = TRUE;
     KeSetEvent(&Device->DeviceRemovalEvent, IO_NO_INCREMENT, FALSE);
-
-    WNBD_LOG_LOUD(": Exit");
 }
 
 // The specified device must be acquired. It will be released by
@@ -283,7 +269,6 @@ WnbdDisconnectAsync(PWNBD_DISK_DEVICE Device)
 VOID
 WnbdDisconnectSync(_In_ PWNBD_DISK_DEVICE Device)
 {
-    WNBD_LOG_LOUD(": Enter");
     // We're holding a device reference, preventing it from being
     // cleaned up while we're accessing it.
     PVOID DeviceMonitorThread = Device->DeviceMonitorThread;
@@ -296,7 +281,6 @@ WnbdDisconnectSync(_In_ PWNBD_DISK_DEVICE Device)
 
     KeWaitForSingleObject(DeviceMonitorThread, Executive, KernelMode, FALSE, NULL);
     ObDereferenceObject(DeviceMonitorThread);
-    WNBD_LOG_LOUD(": Exit");
 }
 
 BOOLEAN

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -59,7 +59,7 @@ NTSTATUS LockUsermodeBuffer(
     {
         Status = GetExceptionCode();
         WNBD_LOG_ERROR("Encountered exception while retrieving user buffer. "
-                       "Exception: %d, buffer: %p, size: %d.",
+                       "Exception: 0x%x, buffer: %p, size: %d.",
                        Status, Buffer, BufferSize);
     }
 
@@ -182,8 +182,8 @@ NTSTATUS WnbdDispatchRequest(
                 Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
                 CompleteRequest(Device, Element, TRUE);
                 InterlockedDecrement64(&Device->Stats.UnsubmittedIORequests);
-                WNBD_LOG_ERROR("Could not get SRB %p 0x%llx data buffer. Error: %d.",
-                               Element->Srb, Element->Tag, StorResult);
+                WNBD_LOG_WARN("Could not get SRB %p 0x%llx data buffer. Error: %lu.",
+                              Element->Srb, Element->Tag, StorResult);
                 continue;
             }
 
@@ -297,16 +297,16 @@ NTSTATUS WnbdHandleResponse(
         if (IsReadSrb(Element->Srb)) {
             StorResult = StorPortGetSystemAddress(Element->DeviceExtension, Element->Srb, &SrbBuff);
             if (STOR_STATUS_SUCCESS != StorResult) {
-                WNBD_LOG_ERROR("Could not get SRB %p 0x%llx data buffer. Error: %d.",
-                               Element->Srb, Element->Tag, StorResult);
+                WNBD_LOG_WARN("Could not get SRB %p 0x%llx data buffer. Error: %lu.",
+                              Element->Srb, Element->Tag, StorResult);
                 Element->Srb->SrbStatus = SRB_STATUS_INTERNAL_ERROR;
                 Status = STATUS_INTERNAL_ERROR;
                 goto Exit;
             }
         }
     } else {
-        WNBD_LOG_WARN("Received reply header for aborted request: %p 0x%llx.",
-                      Element->Srb, Element->Tag);
+        WNBD_LOG_TRACE("Received reply header for aborted request: %p 0x%llx.",
+                       Element->Srb, Element->Tag);
     }
 
     if (!Response->Status.ScsiStatus && IsReadSrb(Element->Srb)) {

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -78,12 +78,12 @@ NTSTATUS WnbdDispatchRequest(
     BOOLEAN BufferLocked = FALSE;
 
     if ((ULONG)Device->Properties.Pid != IoGetRequestorProcessId(Irp)) {
-        WNBD_LOG_LOUD("Invalid pid: %d != %u.",
+        WNBD_LOG_DEBUG("Invalid pid: %d != %u.",
             Device->Properties.Pid, IoGetRequestorProcessId(Irp));
         return STATUS_ACCESS_DENIED;
     }
     if ((ULONG)Device->Properties.Flags.UseNbd) {
-        WNBD_LOG_LOUD("Direct IO is not allowed using NBD devices.");
+        WNBD_LOG_DEBUG("Direct IO is not allowed using NBD devices.");
         return STATUS_ACCESS_DENIED;
     }
 
@@ -133,8 +133,8 @@ NTSTATUS WnbdDispatchRequest(
 
         RtlZeroMemory(Request, sizeof(WNBD_IO_REQUEST));
         WnbdRequestType RequestType = ScsiOpToWnbdReqType(Cdb->AsByte[0]);
-        WNBD_LOG_LOUD("Processing request. Address: %p Tag: 0x%llx Type: %d",
-                      Element->Srb, Element->Tag, RequestType);
+        WNBD_LOG_DEBUG("Processing request. Address: %p Tag: 0x%llx Type: %d",
+                       Element->Srb, Element->Tag, RequestType);
 
         if (!ValidateScsiRequest(Device, Element)) {
             Element->Srb->DataTransferLength = 0;
@@ -259,12 +259,12 @@ NTSTATUS WnbdHandleResponse(
     PWNBD_IO_RESPONSE Response = &Command->Response;
 
     if ((ULONG)Device->Properties.Pid != IoGetRequestorProcessId(Irp)) {
-        WNBD_LOG_LOUD("Invalid pid: %d != %u.",
+        WNBD_LOG_DEBUG("Invalid pid: %d != %u.",
             Device->Properties.Pid, IoGetRequestorProcessId(Irp));
         return STATUS_ACCESS_DENIED;
     }
     if ((ULONG)Device->Properties.Flags.UseNbd) {
-        WNBD_LOG_LOUD("Direct IO is not allowed using NBD devices.");
+        WNBD_LOG_DEBUG("Direct IO is not allowed using NBD devices.");
         return STATUS_ACCESS_DENIED;
     }
 
@@ -281,7 +281,7 @@ NTSTATUS WnbdHandleResponse(
     }
     KeReleaseSpinLock(&Device->SubmittedReqListLock, Irql);
     if (!Element) {
-        WNBD_LOG_LOUD("Received reply with no matching request tag: 0x%llx",
+        WNBD_LOG_DEBUG("Received reply with no matching request tag: 0x%llx",
             Response->RequestHandle);
         return STATUS_NOT_FOUND;
     }
@@ -291,8 +291,8 @@ NTSTATUS WnbdHandleResponse(
         // We need to avoid accessing aborted or already completed SRBs.
         PCDB Cdb = (PCDB)&Element->Srb->Cdb;
         WnbdRequestType RequestType = ScsiOpToWnbdReqType(Cdb->AsByte[0]);
-        WNBD_LOG_LOUD("Received reply header for %d %p 0x%llx.",
-                      RequestType, Element->Srb, Element->Tag);
+        WNBD_LOG_DEBUG("Received reply header for %d %p 0x%llx.",
+                       RequestType, Element->Srb, Element->Tag);
 
         if (IsReadSrb(Element->Srb)) {
             StorResult = StorPortGetSystemAddress(Element->DeviceExtension, Element->Srb, &SrbBuff);
@@ -305,7 +305,7 @@ NTSTATUS WnbdHandleResponse(
             }
         }
     } else {
-        WNBD_LOG_TRACE("Received reply header for aborted request: %p 0x%llx.",
+        WNBD_LOG_DEBUG("Received reply header for aborted request: %p 0x%llx.",
                        Element->Srb, Element->Tag);
     }
 


### PR DESCRIPTION
This PR is intended to clean the wnbd log messages.

- Remove leading `: ` from log messages.

- Fix format specifiers.

- Demote some log messages.

- Print NTSTATUS as hex instead of integer format.

- Remove extraneous arguments passed to log messages
