### PR TITLE
Add etw support

### DIFF
--- a/driver/debug.c
+++ b/driver/debug.c
@@ -10,6 +10,7 @@
 
 #include "debug.h"
 #include "options.h"
+#include "events.h"
 
 #define WNBD_LOG_BUFFER_SIZE 512
 
@@ -39,5 +40,19 @@ WnbdLog(UINT32 Level,
     RtlStringCbVPrintfA(Buf, sizeof(Buf), Format, Args);
     va_end(Args);
 
+    /* Log via ETW */
+    switch (Level) {
+        case WNBD_LVL_ERROR:
+            EventWriteErrorEvent(NULL, FuncName, Line, Buf);
+        break;
+        case WNBD_LVL_WARN:
+            EventWriteWarningEvent(NULL, FuncName, Line, Buf);
+        break;
+        default:
+            EventWriteInformationalEvent(NULL, FuncName, Line, Buf);
+        break;
+    }
+
+    /* Default logging */
     DbgPrintEx(DPFLTR_SCSIMINIPORT_ID, Level, "%s:%lu %s\n", FuncName, Line, Buf);
 }

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -12,6 +12,7 @@
 #include "userspace.h"
 #include "util.h"
 #include "options.h"
+#include "events.h"
 
 DRIVER_INITIALIZE DriverEntry;
 DRIVER_UNLOAD WnbdDriverUnload;
@@ -29,6 +30,11 @@ NTSTATUS
 DriverEntry(PDRIVER_OBJECT DriverObject,
             PUNICODE_STRING RegistryPath)
 {
+    /*
+     * Register with ETW
+     */
+    EventRegisterWNBD();
+
     /*
      * Register Virtual Storport Miniport data
      */
@@ -173,4 +179,9 @@ WnbdDriverUnload(PDRIVER_OBJECT DriverObject)
     if (0 != StorPortDriverUnload) {
         StorPortDriverUnload(DriverObject);
     }
+
+    /*
+     *  Unregister from ETW
+     */
+    EventUnregisterWNBD();
 }

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -47,6 +47,18 @@
     <DriverType>WDM</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemGroup Label="WrappedTaskItems">
+    <MessageCompile Include="wnbdevents.xml">
+      <GenerateKernelModeLoggingMacros>true</GenerateKernelModeLoggingMacros>
+      <HeaderFilePath>.\$(IntDir)</HeaderFilePath>
+      <GeneratedHeaderPath>true</GeneratedHeaderPath>
+      <WinmetaPath>"$(SDK_INC_PATH)\winmeta.xml"</WinmetaPath>
+      <RCFilePath>.\$(IntDir)</RCFilePath>
+      <GeneratedRCAndMessagesPath>true</GeneratedRCAndMessagesPath>
+      <GeneratedFilesBaseName>events</GeneratedFilesBaseName>
+      <UseBaseNameOfInput>true</UseBaseNameOfInput>
+    </MessageCompile>
+  </ItemGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -57,21 +69,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>wnbd</TargetName>
-    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(CRT_IncludePath);$(KM_IncludePath);$(KIT_SHARED_IncludePath);$(IncludePath);$(IntDir)</IncludePath>
     <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
     <IntDir>$(Platform)\$(ConfigurationName)\obj\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>

--- a/vstudio/reinstall.ps1
+++ b/vstudio/reinstall.ps1
@@ -5,6 +5,7 @@ $wnbdBin = "$scriptLocation\wnbd-client.exe"
 $wnbdInf = "$scriptLocation\wnbd.inf"
 $wnbdCat = "$scriptLocation\wnbd.cat"
 $wnbdSys = "$scriptLocation\wnbd.sys"
+$wnbdEvents = "$scriptLocation\wnbdevents.xml"
 
 $requiredFiles = @($wnbdBin, $wnbdInf, $wnbdCat, $wnbdSys)
 foreach ($path in $requiredFiles) {
@@ -13,6 +14,8 @@ foreach ($path in $requiredFiles) {
     }
 }
 
+wevtutil um $wnbdEvents
 & $wnbdBin uninstall-driver
 
+wevtutil im $wnbdEvents
 & $wnbdBin install-driver $wnbdInf

--- a/vstudio/wnbdevents.xml
+++ b/vstudio/wnbdevents.xml
@@ -1,0 +1,72 @@
+﻿<?xml version='1.0' encoding='utf-8' standalone='yes'?>
+<instrumentationManifest
+    xmlns="http://schemas.microsoft.com/win/2004/08/events"
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.microsoft.com/win/2004/08/events eventman.xsd">
+    <instrumentation>
+        <events>
+            <provider
+                guid="{FFACC4E7-C115-4FE2-9D3C-80FAE73BAB91}"
+                messageFileName="%WINDIR%\System32\drivers\wnbd.sys"
+                name="WNBD"
+                resourceFileName="%WINDIR%\System32\drivers\wnbd.sys"
+                symbol="WNBD">
+                <channels>
+                    <importChannel
+                        chid="SYSTEM"
+                        name="System"/>
+                </channels>
+                <templates>
+                    <template tid="tid_load_template">
+                        <data name="FunctionName"
+                              inType="win:AnsiString"
+                              outType="xs:string"/>
+                        <data name="LineNumber"
+                              inType="win:UInt32"
+                              outType="xs:unsignedInt"/>
+                        <data name="Message"
+                              inType="win:AnsiString"
+                              outType="xs:string"/>
+                    </template>
+                </templates>
+                <events>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Error"
+                        message="$(string.ErrorEvent.EventMessage)"
+                        opcode="win:Info"
+                        symbol="ErrorEvent"
+                        template="tid_load_template"
+                        value="1"/>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Warning"
+                        message="$(string.WarningEvent.EventMessage)"
+                        opcode="win:Info"
+                        symbol="WarningEvent"
+                        template="tid_load_template"
+                        value="2"/>
+                    <event
+                        channel="SYSTEM"
+                        level="win:Informational"
+                        message="$(string.InformationalEvent.EventMessage)"
+                        opcode="win:Start"
+                        symbol="InformationalEvent"
+                        template="tid_load_template"
+                        value="3"/>
+                </events>
+            </provider>
+        </events>
+    </instrumentation>
+    <localization xmlns="http://schemas.microsoft.com/win/2004/08/events">
+        <resources culture="en-US">
+            <stringTable>
+                <string id="ErrorEvent.EventMessage" value="%1:%2 %3"/>
+                <string id="WarningEvent.EventMessage" value="%1:%2 %3"/>
+                <string id="InformationalEvent.EventMessage" value="%1:%2 %3"/>
+            </stringTable>
+        </resources>
+    </localization>
+</instrumentationManifest>


### PR DESCRIPTION
Add ETW support for the kernelspace.

For now, we define and use a single variable event which reuses
the messages relayed via WnbdLog.

To install and remove the custom events we need to use the utility:
`wevtutil`

To start a trace session one can use:
tracelog -start WNBDEventdrv -guid #FFACC4E7-C115-4FE2-9D3C-80FAE73BAB91 -f WNBDEventdrv.etl
To stop:
tracelog -stop WNBDEventdrv
To display the trace use:
tracerpt WNBDEventdrv.etl

WNBD error and warning messages are automatically displayed inside the default `SYSTEM` channel.