### PR TITLE
Lowercase SetupAPI.h for cross-compile on Linux

### DIFF
--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -9,7 +9,7 @@
 
 #include <windows.h>
 #include <cfgmgr32.h>
-#include <SetupAPI.h>
+#include <setupapi.h>
 
 #include "wnbd_ioctl.h"
 


### PR DESCRIPTION
Cross-compiling on Linux (as part of the Ceph build) currently fails with:

[ 97%] Building CXX object src/tools/rbd_wnbd/CMakeFiles/rbd-wnbd.dir/rbd_wnbd.cc.obj
In file included from ../ceph/src/tools/rbd_wnbd/wnbd_handler.h:16,
                 from ../ceph/src/tools/rbd_wnbd/wnbd_handler.cc:16:
../ceph/build.deps/src/wnbd/include/wnbd.h:12:10: fatal error: SetupAPI.h: No such file or directory
   12 | #include <SetupAPI.h>
      |          ^~~~~~~~~~~~
compilation terminated.

Fix this by changing setupapi.h to lowercase.

Signed-off-by: Mike Latimer <mlatimer@suse.com>