### PR TITLE
Fix unmap race conditions

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -198,16 +198,19 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
                 break;
             }
 
-            WNBD_LOG_INFO("Removing device.");
+            WNBD_LOG_DEBUG("Removing disk device.");
             PWNBD_DISK_DEVICE Device = WnbdFindDeviceByAddr(
                 GlobalExt, ScsiAddress.PathId,
                 ScsiAddress.TargetId, ScsiAddress.Lun, TRUE);
             if (!Device) {
-                WNBD_LOG_INFO("Device already removed.");
+                WNBD_LOG_DEBUG("Device already removed.");
                 break;
             }
+            WNBD_LOG_INFO("Disconnecting disk: %s.",
+                          Device->Properties.InstanceName);
             WnbdDisconnectSync(Device);
-            WNBD_LOG_INFO("Successfully removed device.");
+            WNBD_LOG_INFO("Successfully disconnected disk: %s",
+                          Device->Properties.InstanceName);
         }
         break;
     }

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -155,6 +155,7 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
             if (!Device) {
                 break;
             }
+            Device->PDO = DeviceObject;
 
             PDEVICE_OBJECT AttachedDisk = IoGetAttachedDeviceReference(DeviceObject);
             if (AttachedDisk != DeviceObject) {
@@ -204,6 +205,13 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
                 ScsiAddress.TargetId, ScsiAddress.Lun, TRUE);
             if (!Device) {
                 WNBD_LOG_DEBUG("Device already removed.");
+                break;
+            }
+            if (Device->PDO != DeviceObject) {
+                WNBD_LOG_INFO(
+                    "Different device found at the specified address. "
+                    "The requested device might've been removed already.");
+                WnbdReleaseDevice(Device);
                 break;
             }
             WNBD_LOG_INFO("Disconnecting disk: %s.",

--- a/driver/scsi_driver_extensions.h
+++ b/driver/scsi_driver_extensions.h
@@ -41,6 +41,7 @@ typedef struct _WNBD_DISK_DEVICE
 
     INT                         DiskNumber;
     WCHAR                       PNPDeviceID[WNBD_MAX_NAME_LENGTH];
+    PDEVICE_OBJECT              PDO;
 
     PINQUIRYDATA                InquiryData;
 

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -22,7 +22,8 @@ WnbdReadCapacity(_In_ PWNBD_DISK_DEVICE Device,
 {
     ASSERT(Srb);
     ASSERT(Cdb);
-    WNBD_LOG_INFO("Using BlockSize: %u, BlockCount: %llu", BlockSize, BlockCount);
+    WNBD_LOG_DEBUG("BlockSize: %u, BlockCount: %llu",
+                   BlockSize, BlockCount);
 
     PVOID DataBuffer = SrbGetDataBuffer(Srb);
     ULONG DataTransferLength = SrbGetDataTransferLength(Srb);

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -326,12 +326,13 @@ WnbdCreateConnection(PWNBD_EXTENSION DeviceExtension,
         goto Exit;
     }
 
+    static UINT64 ConnectionId = 1;
+
     Device->Bus = (USHORT)(bitNumber / MAX_NUMBER_OF_SCSI_TARGETS);
     Device->Target = bitNumber % SCSI_MAXIMUM_TARGETS_PER_BUS;
     Device->Lun = 0;
     Device->DiskNumber = -1;
-    Device->ConnectionId =  WNBD_CONNECTION_ID_FROM_ADDR(
-        Device->Bus, Device->Target, Device->Lun);
+    Device->ConnectionId = (UINT64)InterlockedIncrement64(&(LONG64)ConnectionId);
     WNBD_LOG_INFO("New device address: bus: %d, target: %d, lun: %d, "
                   "connection id: %llu, instance name: %s.",
                   Device->Bus, Device->Target, Device->Lun,

--- a/driver/userspace.h
+++ b/driver/userspace.h
@@ -16,11 +16,6 @@
 #define WNBD_MAX_IN_FLIGHT_REQUESTS 1024
 #define WNBD_PREALLOC_BUFF_SZ (WNBD_DEFAULT_MAX_TRANSFER_LENGTH + sizeof(NBD_REQUEST))
 
-// The connection id provided to the user is meant to be opaque. We're currently
-// using the disk address, but that might change.
-#define WNBD_CONNECTION_ID_FROM_ADDR(PathId, TargetId, Lun) \
-    ((1 << 24 | (PathId) << 16) | ((TargetId) << 8) | (Lun))
-
 NTSTATUS
 WnbdParseUserIOCTL(_In_ PWNBD_EXTENSION DeviceExtension,
                    _In_ PIRP Irp);

--- a/driver/util.c
+++ b/driver/util.c
@@ -155,8 +155,11 @@ WnbdFindDeviceByAddr(
             && Device->Target == TargetId
             && Device->Lun == Lun)
         {
-            if (Acquire && !WnbdAcquireDevice(Device))
+            if (Acquire && !WnbdAcquireDevice(Device)) {
+                WNBD_LOG_DEBUG("Found device but couldn't acquire reference. "
+                               "It's probably being removed.");
                 Device = NULL;
+            }
             break;
         }
         Device = NULL;

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -71,8 +71,8 @@ DWORD WnbdCreate(
         goto Exit;
     }
 
-    LogDebug("Mapped device. Connection id: %llu.",
-             Disk->ConnectionInfo.ConnectionId);
+    LogInfo("Mapped device. Connection id: %llu.",
+            Disk->ConnectionInfo.ConnectionId);
 
     *PDisk = Disk;
 


### PR DESCRIPTION
We're using the SCSI address when generating connection IDs as well as when handling PNP remove requests. This is prone to race conditions as the same SCSI address may be reused by a different device after an unmap.

We're going to use a counter instead of the address for the connection ID, just as we do for IO request tags. At the same time, we're going to check the device PDO when handling PNP events.
