### PR TITLE
libwnbd: Demote WnbdIoctlSendResponse logging

### DIFF
--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -868,7 +868,7 @@ DWORD WnbdIoctlSendResponse(
         NULL, 0, &BytesReturned, Overlapped);
 
     if (Status && !(Status == ERROR_IO_PENDING && Overlapped)) {
-        LogWarning(
+        LogDebug(
             "Could not send response. "
             "Connection id: %llu. Request id: %llu. "
             "Error: %d. Error message: %s",


### PR DESCRIPTION
Unmapping a device will spam the log file with a lot of message of the type:
libwnbd.dll!WnbdIoctlSendResponse WARNING Could not send response.
Connection id: 2. Request id: 0. Error: 1168. Error message: Element not found.

Demote the error to debug instead of warning.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>