### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -7,6 +7,12 @@
 #ifndef WNBD_SHARED_H
 #define WNBD_SHARED_H
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// Disable "enum class" warnings, libwnbd must be C compatible.
+#pragma warning(disable:26812)
+#endif
+
 #include <windows.h>
 #include <cfgmgr32.h>
 #include <setupapi.h>
@@ -382,6 +388,10 @@ static inline const CHAR* WnbdLogLevelToStr(WnbdLogLevel LogLevel) {
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 
 #endif /* WNBD_SHARED_H */

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -7,6 +7,12 @@
 #ifndef WNBD_IOCTL_H
 #define WNBD_IOCTL_H
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// Disable "enum class" warnings, libwnbd must be C compatible.
+#pragma warning(disable:26812)
+#endif
+
 #include <assert.h>
 
 #define WNBD_REGISTRY_KEY "SYSTEM\\CurrentControlSet\\Services\\wnbd"
@@ -426,5 +432,9 @@ typedef struct {
     BYTE Reserved[256];
 } WNBD_VERSION, *PWNBD_VERSION;
 WNBD_ASSERT_SZ_EQ(WNBD_VERSION, 396);
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // WNBD_IOCTL_H

--- a/ksocket_wsk/berkeley.c
+++ b/ksocket_wsk/berkeley.c
@@ -366,7 +366,7 @@ int GetAddrInfo(const char* node, const char* service, const struct addrinfo* hi
   //
 
   ANSI_STRING NodeNameAnsi;
-  UNICODE_STRING NodeNameUnicode;
+  UNICODE_STRING NodeNameUnicode = { 0 };
   PUNICODE_STRING NodeName = NULL;
   RtlInitAnsiString(&NodeNameAnsi, "");
   RtlAnsiStringToUnicodeString(&NodeNameUnicode, &NodeNameAnsi, TRUE);
@@ -391,7 +391,7 @@ int GetAddrInfo(const char* node, const char* service, const struct addrinfo* hi
 
   ANSI_STRING ServiceNameAnsi;
   RtlInitAnsiString(&ServiceNameAnsi, "");
-  UNICODE_STRING ServiceNameUnicode;
+  UNICODE_STRING ServiceNameUnicode = { 0 };
   RtlAnsiStringToUnicodeString(&ServiceNameUnicode, &ServiceNameAnsi, TRUE);
   PUNICODE_STRING ServiceName = NULL;
 

--- a/ksocket_wsk/ksocket.c
+++ b/ksocket_wsk/ksocket.c
@@ -304,8 +304,8 @@ KsDestroy(
 NTSTATUS
 NTAPI
 KsGetAddrInfo(
-  _In_ PUNICODE_STRING NodeName,
-  _In_ PUNICODE_STRING ServiceName,
+  _In_opt_ PUNICODE_STRING NodeName,
+  _In_opt_ PUNICODE_STRING ServiceName,
   _In_ PADDRINFOEXW Hints,
   _Out_ PADDRINFOEXW* Result
   )

--- a/ksocket_wsk/ksocket.h
+++ b/ksocket_wsk/ksocket.h
@@ -23,8 +23,8 @@ KsDestroy(
 NTSTATUS
 NTAPI
 KsGetAddrInfo(
-  _In_ PUNICODE_STRING NodeName,
-  _In_ PUNICODE_STRING ServiceName,
+  _In_opt_ PUNICODE_STRING NodeName,
+  _In_opt_ PUNICODE_STRING ServiceName,
   _In_ PADDRINFOEXW Hints,
   _Out_ PADDRINFOEXW* Result
   );

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -535,14 +535,18 @@ DWORD WnbdSendResponseEx(
 
     if (Response->Status.ScsiStatus) {
         switch(Response->RequestType) {
-            case WnbdReqTypeRead:
-                InterlockedIncrement64((PLONG64)&Disk->Stats.ReadErrors);
-            case WnbdReqTypeWrite:
-                InterlockedIncrement64((PLONG64)&Disk->Stats.WriteErrors);
-            case WnbdReqTypeFlush:
-                InterlockedIncrement64((PLONG64)&Disk->Stats.FlushErrors);
-            case WnbdReqTypeUnmap:
-                InterlockedIncrement64((PLONG64)&Disk->Stats.UnmapErrors);
+        case WnbdReqTypeRead:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.ReadErrors);
+            break;
+        case WnbdReqTypeWrite:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.WriteErrors);
+            break;
+        case WnbdReqTypeFlush:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.FlushErrors);
+            break;
+        case WnbdReqTypeUnmap:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.UnmapErrors);
+            break;
         }
     }
 

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -348,7 +348,7 @@ DWORD RemoveWnbdAdapterDevice(
     PSP_DEVINFO_DATA DevInfoData,
     PBOOL RebootRequired)
 {
-    if (!DeviceInfoList) {
+    if (!DeviceInfoList || !DevInfoData) {
         LogError("Missing adapter device list.");
         return ERROR_INVALID_HANDLE;
     }
@@ -368,7 +368,11 @@ DWORD RemoveWnbdAdapterDevice(
     // Queue the device for removal before trying to remove the
     // OEM information file
     BOOL DeviceRemovalRequiresReboot = FALSE;
-    if (!DiUninstallDevice(0, DeviceInfoList, DevInfoData, 0,
+    #pragma warning(push)
+    #pragma warning(disable:6387)
+    // The first "DiUninstallDevice" parameter is missing the
+    // "_In_opt_" annotation, although it's optional and can be NULL.
+    if (!DiUninstallDevice(NULL, DeviceInfoList, DevInfoData, 0,
                            &DeviceRemovalRequiresReboot)) {
         Status = GetLastError();
         LogError(
@@ -376,6 +380,7 @@ DWORD RemoveWnbdAdapterDevice(
             "Error: %d. Error message: %s",
             Status, win32_strerror(Status).c_str());
     }
+    #pragma warning(pop)
     // Avoid changing the input "RebootRequired" value if this specific
     // device removal didn't require a reboot.
     if (DeviceRemovalRequiresReboot) {

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -4,10 +4,11 @@
  * Licensed under LGPL-2.1 (see LICENSE)
  */
 
+#include <wnbd.h>
+
 #include "client.h"
 #include "cmd.h"
 #include "usage.h"
-#include "wnbd.h"
 #include "version.h"
 
 #include <boost/exception/diagnostic_information.hpp>

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -4,8 +4,9 @@
  * Licensed under LGPL-2.1 (see LICENSE)
  */
 
+#include <wnbd.h>
+
 #include "cmd.h"
-#include "wnbd.h"
 #include "nbd_protocol.h"
 #include "version.h"
 

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -19,8 +19,7 @@
 
 #include <string>
 
-/* WNBD Defines */
-#include "wnbd.h"
+#include <wnbd.h>
 
 #define WNBD_CLI_OWNER_NAME "wnbd-client"
 

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -6,10 +6,6 @@
 
 #include "client.h"
 
-#include <string>
-
-#include <wnbd.h>
-
 int main(int argc, const char** argv)
 {
     return Client().execute(argc, argv);


### PR DESCRIPTION
Fix compiler warnings

A few functions have incorrect annotations, which raises static code
analysis warnings. One of the functions is "DiUninstallDevice", which
is part of the Windows SDK so we can't do anything other than wrap it
with "pragma"s.

At the same time, we have an incorrect "switch" statement, which will
incorrectly count IO errors.

Also, we're disabling the 26812 warning. The wnbd public headers
include enums and we can't use "enum class" since we have to be retain
C compatibility.