### PR TITLE
driver: fix missing disk number

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -139,7 +139,9 @@ WnbdDispatchPnp(PDEVICE_OBJECT DeviceObject,
         break;
     case IRP_MN_START_DEVICE:
         {
-            if (NULL == GlobalExt || !GlobalExt->DeviceCount) {
+            if (!GlobalExt) {
+                WNBD_LOG_DEBUG("IRP_MN_START_DEVICE received but the extension "
+                               "hasn't been initialized.");
                 break;
             }
             Status = WnbdGetScsiAddress(DeviceObject, &ScsiAddress);


### PR DESCRIPTION
When receiving IRP_MN_START_DEVICE, we check if the device count
is nonzero. The issue is that this counter is incremented *after*
storport gets notified that a new device has been created.

In some cases, we skip fetching the disk number because of that.
It happens on WS2016 VMs for every attached disk.

We'll drop this unnecessary device counter check.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>