### PR TITLE
Enforce TLS1.2 in PowerShell

### DIFF
--- a/get_dependencies.ps1
+++ b/get_dependencies.ps1
@@ -6,6 +6,9 @@ $scriptLocation = [System.IO.Path]::GetDirectoryName(
     $myInvocation.MyCommand.Definition)
 $ErrorActionPreference = "Stop"
 
+# Enforce Tls1.2, as most modern websites require it
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $nugetUrl = "https://dist.nuget.org/win-x86-commandline/v4.5.1/nuget.exe"
 
 $depsDir = "$scriptLocation\vstudio\deps"


### PR DESCRIPTION
Most modern websites require TLS 1.2, and older PowerShell versions do not enforce it by default.