### PR TITLE
Update appveyor script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You can also download the latest prebuilt packages from Appveyor via the links:
 
 [This project](https://github.com/cloudbase/ceph-windows-installer) allows building
 an MSI installer that bundles WNBD and the Ceph Windows clients.
+[Here's](https://cloudbase.it/downloads/ceph_v16_0_0_beta.msi) a nightly build of
+the Ceph Pacific MSI installer.
 
 How to install
 --------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,7 @@ init:
 build_script:
 - '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
 - msbuild C:\wnbd\vstudio\wnbd.sln /property:Configuration=%CONFIGURATION%
-- copy C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\* .
-- 7z a wnbd-%CONFIGURATION%.zip C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.cat C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.inf C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.sys C:\wnbd\vstudio\x64\%CONFIGURATION%\wnbd-client.exe
+- 7z a wnbd-%CONFIGURATION%.zip C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.cat C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.inf C:\wnbd\vstudio\x64\%CONFIGURATION%\driver\wnbd.sys C:\wnbd\vstudio\x64\%CONFIGURATION%\wnbd-client.exe C:\wnbd\vstudio\x64\%CONFIGURATION%\libwnbd.dll C:\wnbd\vstudio\reinstall.ps1 C:\wnbd\vstudio\wnbdevents.xml
 
 artifacts:
   - path: wnbd-%CONFIGURATION%.zip


### PR DESCRIPTION
We're updating the appveyor artifacts to include libwnbd, the
install script as well as the ETW manifest.

While at it, we're adding a link to the Ceph beta MSI, which
includes a WNBD build.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>