### PR TITLE
Use explicit SHA256 fd algorithm for driver sign

### DIFF
--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -103,6 +103,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;$(DDK_LIB_PATH )libcntpr.lib;$(DDK_LIB_PATH )wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -117,6 +120,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>


### PR DESCRIPTION
Using the new Windows 11 SDK + WDK (10.0.22000.0), the testing build errors out with:
```
The driver will be test-signed. Driver signing options can be changed from the project properties.
  Sign Inputs: C:\workspace\wnbd\vstudio\x64\Debug\wnbd.sys

  C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86\signtool.exe sign /ph /sha1 "8010D8632A9CC49D4782603AC417B493534C23C0"

SIGNTASK : SignTool error : No file digest algorithm specified. Please specify the digest algorithm with the /fd flag. Using /fd SHA256 is recommended and more secure than SHA1. Calling signtool with /fd sha1 is equivalent to the previous behavior. In order to select the hash algorithm used in the signing certificate's signature, use the /fd certHash option. [C:\workspace\wnbd\vstudio\driver.vcxproj]
```

Explicitly setting the `DriverSign/FileDigestAlgorithm` to `SHA256` fixes the build error.