### PR TITLE
Improved error message when the wnbd adapter is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ storage adapters and then remove any previous installations of the driver.
 After installing the driver, you may want to copy ``wnbd-client.exe`` and ``libwnbd.dll``
 to a directory that's part of the ``PATH`` environment variable.
 
+Note that a host reboot may be required after installing or uninstalling the
+WNBD driver.
+
 Version
 -------
 

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -217,11 +217,13 @@ Exit:
             if (ExpectExisting)
                 LogError(
                     "No WNBD adapter found. Please make sure that the driver "
-                    "is installed.");
+                    "is installed. A reboot may be required after "
+                    "installing the driver.");
         } else {
             LogError(
                 "Could not open WNBD adapter device. Please make sure that "
-                "the driver is installed. Error: %d. Error message: %s",
+                "the driver is installed. A reboot may be required after "
+                "installing the driver. Error: %d. Error message: %s",
                 Status, win32_strerror(Status).c_str());
         }
     }


### PR DESCRIPTION
Improved error message when the wnbd adapter is unavailable

In some cases, the WNBD adapter may be unavailable after
(re)installing the driver, which may require a host reboot.

In order to improve the user experience, we'll update the error
message accordingly.