### PR TITLE
Fix Appveyor job

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,9 @@ branches:
   only:
   - master
 configuration:
-  - Analyze
+  # We're currently skipping the "Analyze" Appveyor job. It's a resource
+  # intensive operation that often times out.
+  # - Analyze
   - Debug
   - Release
 clone_folder: C:\wnbd

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -132,6 +132,9 @@
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)\pdb\$(ProjectName)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
     <PostBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -command $env:VCINSTALLDIR='$(VCInstallDir)'; cd $(SolutionDir); msbuild $(SolutionFileName) /p:Configuration=Release; msbuild $(ProjectFileName) /t:sdv /p:inputs='/check' /p:Configuration=Release /p:SolutionDir=$(SolutionDir); msbuild $(ProjectFileName) /p:Configuration=Release /P:RunCodeAnalysisOnce=True</Command>
     </PostBuildEvent>


### PR DESCRIPTION
Fix Appveyor job

The CI job is currently failing as the signing algorithm is set for "Release" and "Debug" builds but not for the "Analyze" one.

At the same time, the Analyze job is a resource intensive operation which now times out under Appveyor, for which reason we're going to temporarily disable it.

When preparing or reviewing driver changes, we recommend running the static code analysis by invoking the "Analyze" build locally.