### PR TITLE
Temporarily mirror main branch

### DIFF
--- a/.github/workflows/mirror-main-branch.yaml
+++ b/.github/workflows/mirror-main-branch.yaml
@@ -1,0 +1,30 @@
+name: Mirror main branch
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  master:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch the entire git history (the default is `fetch-depth: 1`)
+
+      - name: Mirror to master branch
+        run: |
+          set -e
+          if ! git show-ref --quiet master; then
+            # create new branch if it doesn't already exist
+            CHECKOUT_OPTS="-b"
+          fi
+          git checkout $CHECKOUT_OPTS master
+          git rebase main
+          git push origin master


### PR DESCRIPTION
Use this GitHub workflow to mirror the default `main` branch to
the old `master` branch until all the references to `main` branch
are updated.