### PR TITLE
documentation: fix libwnbd.dll filename

### DIFF
--- a/Dockerfile/Readme.md
+++ b/Dockerfile/Readme.md
@@ -38,5 +38,5 @@ git clone https://github.com/cloudbase/wnbd
 msbuild wnbd\vstudio\wnbd.sln
 copy wnbd\vstudio\x64\Debug\driver\* .
 copy wnbd\vstudio\x64\Debug\wnbd-client.exe .
-copy wnbd\vstudio\x64\Debug\wnbd.dll .
+copy wnbd\vstudio\x64\Debug\libwnbd.dll .
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ connect to a [Network Block Device (NBD)](https://nbd.sourceforge.io/) server, w
 device details and acts as an IO channel. As an alternative, it can dispatch IO commands to
 an userspace process using a DeviceIoControl based interface.
 
-The project also provides the ``wnbd.dll`` library, which handles the userspace and driver
+The project also provides the ``libwnbd.dll`` library, which handles the userspace and driver
 communication. It provides the following features:
 
 * Creating WNBD devices (optionally connecting to a NBD server)
@@ -48,7 +48,7 @@ Folders
 * [include](include/) public headers
 * [ksocket_wsk](ksocket_wsk/) a WSK wrapper used to communicate with the Network Block Device server
 * [wnbd-client](wnbd-client/) the WNBD CLI
-* [libwnbd](libwbd/) ``wnbd.dll`` - the WNBD userspace library
+* [libwnbd](libwbd/) ``libwnbd.dll`` - the WNBD userspace library
 * [vstudio](vstudio/) the Visual Studio solution file and its projects
 
 How to build

--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -100,7 +100,7 @@ summarizing the change, and prefixed with the module you are changing.
 Also, it is conventional to use the imperative mood in the commit title.
 Positive examples include::
 
-     wnbd-client: Use wnbd.dll
+     wnbd-client: Use libwnbd.dll
 
 Some negative examples (how *not* to title a commit message)::
 


### PR DESCRIPTION
Commit 9f0d43bf3a63a3e44f65ef2453413d9203eaa71a renamed `wnbd.dll` to `libwnbd.dll`. Clean up stray references to `wnbd.dll`.