### PR TITLE
Add persistent reservation support

### DIFF
--- a/driver/util.h
+++ b/driver/util.h
@@ -63,6 +63,8 @@ WnbdFindDeviceByInstanceName(
 
 BOOLEAN
 IsReadSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
+BOOLEAN
+IsPerResInSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
 
 VOID DisconnectSocket(_In_ PWNBD_DISK_DEVICE Device);
 VOID CloseSocket(_In_ PWNBD_DISK_DEVICE Device);
@@ -99,6 +101,10 @@ ScsiOpToWnbdReqType(int ScsiOp)
     case SCSIOP_SYNCHRONIZE_CACHE:
     case SCSIOP_SYNCHRONIZE_CACHE16:
         return WnbdReqTypeFlush;
+    case SCSIOP_PERSISTENT_RESERVE_IN:
+        return WnbdReqTypePersistResIn;
+    case SCSIOP_PERSISTENT_RESERVE_OUT:
+        return WnbdReqTypePersistResOut;
     default:
         return WnbdReqTypeUnknown;
     }

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -60,7 +60,9 @@ typedef struct _WNBD_USR_STATS
     UINT64 TotalRWRequests;
     UINT64 TotalReadBlocks;
     UINT64 TotalWrittenBlocks;
-    BYTE Reserved[144];
+    UINT64 PersistResInErrors;
+    UINT64 PersistResOutErrors;
+    BYTE Reserved[128];
 } WNBD_USR_STATS, *PWNBD_USR_STATS;
 WNBD_ASSERT_SZ_EQ(WNBD_USR_STATS, 256);
 
@@ -129,6 +131,18 @@ typedef VOID (*LogMessageFunc)(
     const char* FileName,
     UINT32 Line,
     const char* FunctionName);
+typedef VOID (*PersistResInFunc)(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    UINT8 ServiceAction);
+typedef VOID (*PersistResOutFunc)(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    UINT8 ServiceAction,
+    UINT8 Scope,
+    UINT8 Type,
+    PVOID Buffer,
+    UINT32 ParameterListLength);
 
 // The following IO callbacks should be implemented by the consumer when
 // not using NBD. As an alternative, the underlying *Ioctl* functions may
@@ -139,7 +153,9 @@ typedef struct _WNBD_INTERFACE
     WriteFunc Write;
     FlushFunc Flush;
     UnmapFunc Unmap;
-    VOID* Reserved[15];
+    PersistResInFunc PersistResIn;
+    PersistResOutFunc PersistResOut;
+    VOID* Reserved[13];
 } WNBD_INTERFACE, *PWNBD_INTERFACE;
 WNBD_ASSERT_SZ_EQ(WNBD_INTERFACE, 152);
 

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -59,7 +59,9 @@ typedef enum
     WnbdReqTypeWrite = 2,
     WnbdReqTypeFlush = 3,
     WnbdReqTypeUnmap = 4,
-    WnbdReqTypeDisconnect = 5
+    WnbdReqTypeDisconnect = 5,
+    WnbdReqTypePersistResIn = 6,
+    WnbdReqTypePersistResOut = 7,
 } WnbdRequestType;
 
 typedef UINT64 WNBD_CONNECTION_ID;
@@ -111,7 +113,8 @@ typedef struct
     // be submitted through the IOCTL_WNBD_FETCH_REQ/IOCTL_WNBD_SEND_RSP
     // DeviceIoControl commands.
     UINT32 UseNbd:1;
-    UINT32 Reserved: 26;
+    UINT32 PersistResSupported:1;
+    UINT32 Reserved: 25;
 } WNBD_FLAGS, *PWNBD_FLAGS;
 WNBD_ASSERT_SZ_EQ(WNBD_FLAGS, 4);
 
@@ -227,6 +230,18 @@ typedef struct
             UINT32 Anchor:1;
             UINT32 Reserved:31;
         } Unmap;
+        struct
+        {
+            UINT8 ServiceAction;
+            UINT16 AllocationLength;
+        } PersistResIn;
+        struct
+        {
+            UINT8 ServiceAction;
+            UINT8 Scope:4;
+            UINT8 Type:4;
+            UINT16 ParameterListLength;
+        } PersistResOut;
     } Cmd;
     BYTE Reserved[32];
 } WNBD_IO_REQUEST, *PWNBD_IO_REQUEST;
@@ -419,6 +434,10 @@ static inline const CHAR* WnbdRequestTypeToStr(WnbdRequestType RequestType) {
             return "UNMAP";
         case WnbdReqTypeDisconnect:
             return "DISCONNECT";
+        case WnbdReqTypePersistResIn:
+            return "PERSISTENT_RESERVE_IN";
+        case WnbdReqTypePersistResOut:
+            return "PERSISTENT_RESERVE_OUT";
         default:
             return "UNKNOWN";
     }

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -37,7 +37,7 @@ DWORD WnbdCreate(
     ErrorCode = WnbdOpenAdapter(&Disk->Handle);
 
     LogDebug("Mapping device. Name=%s, Serial=%s, Owner=%s, "
-             "BC=%llu, BS=%lu, RO=%u, Flush=%u, "
+             "BC=%llu, BS=%lu, RO=%u, Flush=%u, PerRes=%u, "
              "Unmap=%u, UnmapAnchor=%u, MaxUnmapDescCount=%u, "
              "Nbd=%u.",
              Properties->InstanceName,
@@ -47,6 +47,7 @@ DWORD WnbdCreate(
              Properties->BlockSize,
              Properties->Flags.ReadOnly,
              Properties->Flags.FlushSupported,
+             Properties->Flags.PersistResSupported,
              Properties->Flags.UnmapSupported,
              Properties->Flags.UnmapAnchorSupported,
              Properties->MaxUnmapDescCount,
@@ -547,6 +548,12 @@ DWORD WnbdSendResponseEx(
         case WnbdReqTypeUnmap:
             InterlockedIncrement64((PLONG64)&Disk->Stats.UnmapErrors);
             break;
+        case WnbdReqTypePersistResIn:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.PersistResInErrors);
+            break;
+        case WnbdReqTypePersistResOut:
+            InterlockedIncrement64((PLONG64)&Disk->Stats.PersistResOutErrors);
+            break;
         }
     }
 
@@ -668,6 +675,42 @@ VOID WnbdHandleRequest(PWNBD_DISK Disk, PWNBD_IO_REQUEST Request,
                 Request->RequestHandle,
                 (PWNBD_UNMAP_DESCRIPTOR)Buffer,
                 Request->Cmd.Unmap.Count);
+            break;
+        case WnbdReqTypePersistResIn:
+            if (!Disk->Interface->PersistResIn ||
+                    !Disk->Properties.Flags.PersistResSupported)
+                goto Unsupported;
+            LogDebug("Dispatching PERSISTENT_RESERVE_IN(action=0x%x) "
+                        "allocLen=0x%x # %llx.",
+                     Request->Cmd.PersistResIn.ServiceAction,
+                     Request->Cmd.PersistResIn.AllocationLength,
+                     Request->RequestHandle);
+
+            Disk->Interface->PersistResIn(
+                Disk,
+                Request->RequestHandle,
+                Request->Cmd.PersistResIn.ServiceAction);
+            break;
+        case WnbdReqTypePersistResOut:
+            if (!Disk->Interface->PersistResOut ||
+                    !Disk->Properties.Flags.PersistResSupported)
+                goto Unsupported;
+            LogDebug("Dispatching PERSISTENT_RESERVE_OUT"
+                        "(action=0x%x, scope=0x%x, type=0x%x) "
+                        "paramListLen=0x%x # %llx.",
+                     Request->Cmd.PersistResOut.ServiceAction,
+                     Request->Cmd.PersistResOut.Scope,
+                     Request->Cmd.PersistResOut.Type,
+                     Request->Cmd.PersistResOut.ParameterListLength,
+                     Request->RequestHandle);
+            Disk->Interface->PersistResOut(
+                Disk,
+                Request->RequestHandle,
+                Request->Cmd.PersistResOut.ServiceAction,
+                Request->Cmd.PersistResOut.Scope,
+                Request->Cmd.PersistResOut.Type,
+                Buffer,
+                Request->Cmd.PersistResOut.ParameterListLength);
             break;
         default:
         Unsupported:


### PR DESCRIPTION
Add persistent reservation support

We're making the necessary driver and libwnbd changes so that userspace daemons may receive scsi persistent reservation requests, when advertised as supported.

To keep things simple, we're only defining two libwnbd callbacks: ``PersistInFunc`` and ``PersistOutFunc``. The libwnbd consumers will have to decode the scsi operation parameters and return the expected data.