### PR TITLE
libwnbd: Unmap invalid requests fix

### DIFF
--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -690,7 +690,13 @@ VOID WnbdHandleRequest(PWNBD_DISK Disk, PWNBD_IO_REQUEST Request,
                          AdditionalSenseCode);
             // Avoid negative count
             InterlockedIncrement64((PLONG64)&Disk->Stats.PendingSubmittedRequests);
-            WnbdSendResponse(Disk, &Response, NULL, 0);
+            DWORD Status = WnbdSendResponse(Disk, &Response, NULL, 0);
+            
+            if (Status == ERROR_NOT_FOUND) {
+                LogDebug("Unable to send response, device not found. Performing cleanup.");
+                WnbdSignalStopped(Disk);
+            }
+
             break;
     }
 

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -217,6 +217,9 @@ DWORD WnbdRemoveEx(
                            "Falling back to hard removal.");
             }
         }
+        else {
+            LogDebug("PNP removal succeeded");
+        }
     }
     Status = WnbdIoctlRemove(Handle, InstanceName, NULL, NULL);
     CloseHandle(Handle);

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -932,7 +932,7 @@ DWORD WnbdIoctlRemove(
 
     if (Status && !(Status == ERROR_IO_PENDING && Overlapped)) {
         if (Status == ERROR_FILE_NOT_FOUND) {
-            LogDebug("Could not find the disk to be removed.");
+            LogDebug("Could not find the disk to be removed. It might have been removed already.");
         }
         else {
             LogError("Could not remove WNBD disk. Error: %d. Error message: %s",


### PR DESCRIPTION
When a device was unmapped, thousands of invalid requests were received by the IO dispatchers, which in turned tried to send responses to the now missing device.

For solving this issue, we now check the status of the WNBD responses that are being sent, stopping the dispatchers if ERROR_NOT_FOUND is received and proceeding with the unmap.

Also, the log messages for WnbdIoctlRemove were changed as follows:
- included a success message for the soft removal option
- when the hard removal faces ERROR_FILE_NOT_FOUND, the log messages states that the device might have already been removed