### PR TITLE
doc: update limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,12 +381,6 @@ Passing the ``--persistent`` flag will remove the persistent setting as well.
 Limitations
 ===========
 
-### CSV support
-
-At the moment, the Microsoft Failover Cluster can't use WNBD disks as
-Cluster Shared Volumes (CSVs) underlying storage. The main reason is that
-``WNBD`` doesn't support the *SCSI Persistent Reservations* feature yet.
-
 ### Hyper-V disk addressing
 
 **Warning:** Hyper-V identifies passthrough VM disks by number instead of


### PR DESCRIPTION
Now that wnbd supports persistent reservations, we can update the "limitations" section from the readme.

Note that in case of rbd-wnbd, older Ceph versions do not support this feature.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>