### PR TITLE
NBD logging improvements

### DIFF
--- a/driver/nbd_protocol.c
+++ b/driver/nbd_protocol.c
@@ -266,7 +266,7 @@ NbdNegotiate(_In_ INT* Pfd,
                     WNBD_LOG_ERROR("Connection not allowed by server policy.");
                 }
                 NbdFree(Reply);
-                return STATUS_FAIL_CHECK;
+                return STATUS_ACCESS_DENIED;
 
             default:
                 if (Reply->Datasize > 0) {
@@ -487,7 +487,11 @@ NbdReadReply(INT Fd,
 
     NTSTATUS error = STATUS_SUCCESS;
     if (-1 == NbdReadExact(Fd, Reply, sizeof(NBD_REPLY), &error)) {
-        WNBD_LOG_ERROR("Could not read command reply.");
+        if (error == STATUS_CONNECTION_DISCONNECTED) {
+            WNBD_LOG_INFO("NBD connection closed.");
+        } else {
+            WNBD_LOG_ERROR("Could not read command reply.");
+        }
         return error;
     }
 

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -347,7 +347,8 @@ WnbdCreateConnection(PWNBD_EXTENSION DeviceExtension,
         WNBD_LOG_INFO("Connecting to NBD server: %s:%p. "
                       "Export name: %s.",
                       Properties->NbdProperties.Hostname,
-                      Properties->NbdProperties.PortNumber);
+                      Properties->NbdProperties.PortNumber,
+                      Properties->NbdProperties.ExportName);
         Sock = NbdOpenAndConnect(
             Properties->NbdProperties.Hostname,
             Properties->NbdProperties.PortNumber);

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -893,7 +893,9 @@ DWORD WnbdIoctlCreate(
         &Command, sizeof(Command), ConnectionInfo, sizeof(WNBD_CONNECTION_INFO),
         &BytesReturned, Overlapped);
     if (Status && !(Status == ERROR_IO_PENDING && Overlapped)) {
-        LogError("Could not create WNBD disk. Error: %d. Error message: %s",
+        LogError("Could not create WNBD disk. Check the WNBD driver "
+                 "and NBD server logs for more information. "
+                 "Error: %d. Error message: %s",
                  Status, win32_strerror(Status).c_str());
     }
 


### PR DESCRIPTION
driver:
- avoid logging an error when gracefully closing NBD connections
- added missing log message parameter in WnbdCreateConnection, which was causing a crash when mapping NBD images while having INFO logging enabled
- return STATUS_ACCESS_DENIED when failing to connect to nbd servers because of the nbd policy

libwnbd:
- updated the error message for WnbdIoctlCreate, pointing the user to driver and nbd logs