### PR TITLE
driver: handle IRP_MN_QUERY_REMOVE_DEVICE

### DIFF
--- a/driver/util.h
+++ b/driver/util.h
@@ -19,6 +19,8 @@ VOID
 CompleteRequest(_In_ PWNBD_DISK_DEVICE Device,
                 _In_ PSRB_QUEUE_ELEMENT Element,
                 _In_ BOOLEAN FreeElement);
+BOOLEAN
+HasPendingAsyncRequests(_In_ PWNBD_DISK_DEVICE Device);
 
 VOID
 WnbdCleanupAllDevices(_In_ PWNBD_EXTENSION DeviceExtension);


### PR DESCRIPTION
The wnbd driver currently ignores IRP_MN_QUERY_REMOVE_DEVICE calls, expecting the rest of the Windows storage stack to prevent the disk removal if there are pending operations or unflushed data.

As a precaution, we'll add a check at the wnbd driver level, signaling that the disk is not ready to be removed if there are pending requests in our queues.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>