### PR TITLE
libwnbd: Fixed device block count update on resize

### DIFF
--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -318,6 +318,8 @@ DWORD WnbdSetDiskSize(PWNBD_DISK Disk, UINT64 BlockCount) {
         LogError("Failed closing device handle. Error: %d", ErrorCode);
     }
 
+    Disk->Properties.BlockCount = BlockCount;
+
     LogDebug("Exit: %d", ErrorCode);
 
     return ErrorCode;


### PR DESCRIPTION
When calling WnbdSetDiskSize, the block count property of the device received as a parameter wasn't being updated before returning. Therefore, while the actual block count of the device was changed, the property of the referenced PWNBD_DISK wasn't properly updated to the new value.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>