### PR TITLE
Add wnbd tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,7 @@ tags
 /vstudio/sdv/
 /vstudiox64/
 /vstudio/deps
+/vstudio/packages
+/tests/libwnbd_tests/x64
 
 include/version.h

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -48,6 +48,8 @@ static const GUID WNBD_GUID = {
 #define WNBD_MAX_VERSION_STR_LENGTH 128
 #define WNBD_NAA_ID_LENGTH 16
 // For transfers larger than 16MB, Storport sends 0 sized buffers.
+// TODO: "default" suggests that the max transfer length is configurable,
+// however it's not. We shold rename it, dropping the "default" keyword.
 #define WNBD_DEFAULT_MAX_TRANSFER_LENGTH 2 * 1024 * 1024
 
 // Only used for NBD connections, in which case the block size is optional.

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -144,7 +144,7 @@ DWORD PnpRemoveDevice(
                "the disk.",
                CMStatus, VetoType, VetoName,
                ElapsedMs.QuadPart / 1000.0,
-               TimeLeftSS.str());
+               TimeLeftSS.str().c_str());
         }
         if (RemoveVetoed && TimeLeft) {
             Sleep(RetryIntervalMs);

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -968,10 +968,14 @@ DWORD WnbdWaitDispatcher(PWNBD_DISK Disk)
         return ERROR_PIPE_NOT_CONNECTED;
     }
 
-    if (!Disk->DispatcherThreads || !Disk->DispatcherThreadsCount ||
-            !WnbdIsRunning(Disk)) {
+    if (!Disk->DispatcherThreads || !Disk->DispatcherThreadsCount) {
         LogInfo("The dispatcher isn't running.");
         return 0;
+    }
+
+    if (!WnbdIsRunning(Disk)) {
+        LogInfo("Dispatcher stopped, waiting for any remaining "
+                "dispatcher threads.");
     }
 
     DWORD Ret = WaitForMultipleObjects(

--- a/packages.config
+++ b/packages.config
@@ -3,4 +3,5 @@
   <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="boost_filesystem-src" version="1.72.0.0" targetFramework="native" />
   <package id="boost_program_options-src" version="1.72.0.0" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
 </packages>

--- a/tests/libwnbd_tests/libwnbd_tests.vcxproj
+++ b/tests/libwnbd_tests/libwnbd_tests.vcxproj
@@ -25,14 +25,18 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClInclude Include="utils.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="mock_wnbd_daemon.cc" />
+    <ClCompile Include="request_log.cpp" />
     <ClCompile Include="test.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\libwnbd\libwnbd.vcxproj">
@@ -56,10 +60,12 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\include;$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>$(OutDir)\libwnbd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/tests/libwnbd_tests/libwnbd_tests.vcxproj
+++ b/tests/libwnbd_tests/libwnbd_tests.vcxproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{cb9f16ac-7578-4122-a364-a54aa527c426}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\libwnbd\libwnbd.vcxproj">
+      <Project>{15ffee2f-f65a-47d1-8389-15e5add971ca}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..\..\include;$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>$(OutDir)\libwnbd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/tests/libwnbd_tests/libwnbd_tests.vcxproj
+++ b/tests/libwnbd_tests/libwnbd_tests.vcxproj
@@ -49,7 +49,8 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)\deps\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)\deps\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -86,10 +87,4 @@
       <AdditionalDependencies>$(OutDir)\libwnbd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\vstudio\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
-  </Target>
 </Project>

--- a/tests/libwnbd_tests/mock_wnbd_daemon.cc
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.cc
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+
+#include "mock_wnbd_daemon.h"
+#include "utils.h"
+
+MockWnbdDaemon::~MockWnbdDaemon()
+{
+    if (Started && WnbdDisk) {
+        Shutdown();
+
+        WnbdClose(WnbdDisk);
+
+        Started = false;
+    }
+}
+
+void MockWnbdDaemon::Start()
+{
+    WNBD_PROPERTIES WnbdProps = {0};
+
+    InstanceName.copy(WnbdProps.InstanceName, sizeof(WnbdProps.InstanceName));
+    ASSERT_TRUE(strlen(WNBD_OWNER_NAME) < WNBD_MAX_OWNER_LENGTH)
+        << "WnbdOwnerName too long";
+    strncpy_s(
+        WnbdProps.Owner, WNBD_MAX_OWNER_LENGTH,
+        WNBD_OWNER_NAME, strlen(WNBD_OWNER_NAME));
+
+    WnbdProps.BlockCount = BlockCount;
+    WnbdProps.BlockSize = BlockSize;
+    WnbdProps.MaxUnmapDescCount = 1;
+
+    WnbdProps.Flags.ReadOnly = ReadOnly;
+    WnbdProps.Flags.UnmapSupported = 1;
+    if (CacheEnabled) {
+        WnbdProps.Flags.FUASupported = 1;
+        WnbdProps.Flags.FlushSupported = 1;
+    }
+
+    DWORD err = WnbdCreate(
+        &WnbdProps, (const PWNBD_INTERFACE) &MockWnbdInterface,
+        this, &WnbdDisk);
+    ASSERT_FALSE(err) << "WnbdCreate failed";
+
+    Started = true;
+
+    err = WnbdStartDispatcher(WnbdDisk, IO_REQ_WORKERS);
+    ASSERT_FALSE(err) << "WnbdStartDispatcher failed";
+
+    if (!ReadOnly) {
+        SetDiskWritable(InstanceName);
+    }
+}
+
+void MockWnbdDaemon::Shutdown()
+{
+    std::unique_lock<std::mutex> Lock(ShutdownLock);
+    if (!Terminated && WnbdDisk) {
+        TerminateInProgress = true;
+        // We're requesting the disk to be removed but continue serving IO
+        // requests until the driver sends us the "Disconnect" event.
+        DWORD Ret = WnbdRemove(WnbdDisk, NULL);
+        ASSERT_FALSE(Ret) << "couldn't stop the wnbd dispatcher, err: " << Ret;
+        Wait();
+        Terminated = true;
+    }
+}
+
+void MockWnbdDaemon::Wait()
+{
+    if (Started && WnbdDisk) {
+        DWORD err = WnbdWaitDispatcher(WnbdDisk);
+        ASSERT_FALSE(err) << "failed waiting for the dispatcher to stop";
+    }
+}
+
+void MockWnbdDaemon::Read(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    PVOID Buffer,
+    UINT64 BlockAddress,
+    UINT32 BlockCount,
+    BOOLEAN ForceUnitAccess)
+{
+    MockWnbdDaemon* handler = nullptr;
+    ASSERT_FALSE(WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+    ASSERT_TRUE(handler->BlockSize);
+    ASSERT_TRUE(handler->BlockSize * BlockCount
+        <= WNBD_DEFAULT_MAX_TRANSFER_LENGTH);
+
+    WnbdRequestType RequestType = WnbdReqTypeRead;
+    WNBD_IO_REQUEST WnbdReq = { 0 };
+    WnbdReq.RequestType = RequestType;
+    WnbdReq.RequestHandle = RequestHandle;
+    WnbdReq.Cmd.Read.BlockAddress = BlockAddress;
+    WnbdReq.Cmd.Read.BlockCount = BlockCount;
+    WnbdReq.Cmd.Read.ForceUnitAccess = ForceUnitAccess;
+
+    handler->ReqLog.AddEntry(WnbdReq);
+
+    if (Disk->Properties.BlockCount < BlockAddress + BlockCount) {
+        // Overflow
+        // TODO: consider moving this check to the driver.
+        WnbdSetSense(
+            &handler->MockStatus,
+            SCSI_SENSE_ILLEGAL_REQUEST,
+            SCSI_ADSENSE_VOLUME_OVERFLOW);
+    } else {
+        memset(Buffer, READ_BYTE_CONTENT, BlockCount * handler->BlockSize);
+    }
+
+    handler->SendIoResponse(
+        RequestHandle, RequestType,
+        handler->MockStatus,
+        Buffer, handler->BlockSize * BlockCount);
+}
+
+void MockWnbdDaemon::Write(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    PVOID Buffer,
+    UINT64 BlockAddress,
+    UINT32 BlockCount,
+    BOOLEAN ForceUnitAccess)
+{
+    MockWnbdDaemon* handler = nullptr;
+    ASSERT_FALSE(WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+    ASSERT_TRUE(handler->BlockSize);
+    ASSERT_TRUE(handler->BlockSize * BlockCount
+        <= WNBD_DEFAULT_MAX_TRANSFER_LENGTH);
+
+    WnbdRequestType RequestType = WnbdReqTypeWrite;
+    WNBD_IO_REQUEST WnbdReq = { 0 };
+    WnbdReq.RequestType = RequestType;
+    WnbdReq.RequestHandle = RequestHandle;
+    WnbdReq.Cmd.Write.BlockAddress = BlockAddress;
+    WnbdReq.Cmd.Write.BlockCount = BlockCount;
+    WnbdReq.Cmd.Write.ForceUnitAccess = ForceUnitAccess;
+
+    handler->ReqLog.AddEntry(WnbdReq, Buffer, BlockCount * handler->BlockSize);
+
+    WNBD_STATUS Status = handler->MockStatus;
+
+    if (Disk->Properties.BlockCount < BlockAddress + BlockCount) {
+        // Overflow
+        // TODO: consider moving this check to the driver.
+        WnbdSetSense(
+            &Status,
+            SCSI_SENSE_ILLEGAL_REQUEST,
+            SCSI_ADSENSE_VOLUME_OVERFLOW);
+    }
+
+    handler->SendIoResponse(
+        RequestHandle, RequestType,
+        Status,
+        Buffer, handler->BlockSize * BlockCount);
+}
+
+void MockWnbdDaemon::Flush(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    UINT64 BlockAddress,
+    UINT32 BlockCount)
+{
+    MockWnbdDaemon* handler = nullptr;
+    ASSERT_FALSE(WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+    WnbdRequestType RequestType = WnbdReqTypeFlush;
+    WNBD_IO_REQUEST WnbdReq = { 0 };
+    WnbdReq.RequestType = RequestType;
+    WnbdReq.RequestHandle = RequestHandle;
+    WnbdReq.Cmd.Flush.BlockAddress = BlockAddress;
+    WnbdReq.Cmd.Flush.BlockCount = BlockCount;
+
+    handler->ReqLog.AddEntry(WnbdReq);
+
+    if (Disk->Properties.BlockCount < BlockAddress + BlockCount) {
+        // Overflow
+        // TODO: consider moving this check to the driver.
+        WnbdSetSense(
+            &handler->MockStatus,
+            SCSI_SENSE_ILLEGAL_REQUEST,
+            SCSI_ADSENSE_VOLUME_OVERFLOW);
+    }
+
+    handler->SendIoResponse(
+        RequestHandle, RequestType,
+        handler->MockStatus, NULL, 0);
+}
+
+void MockWnbdDaemon::Unmap(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    PWNBD_UNMAP_DESCRIPTOR Descriptors,
+    UINT32 Count)
+{
+    MockWnbdDaemon* handler = nullptr;
+    ASSERT_FALSE(WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+    WnbdRequestType RequestType = WnbdReqTypeUnmap;
+    WNBD_IO_REQUEST WnbdReq = { 0 };
+    WnbdReq.RequestType = RequestType;
+    WnbdReq.RequestHandle = RequestHandle;
+    WnbdReq.Cmd.Unmap.Count = Count;
+
+    handler->ReqLog.AddEntry(
+        WnbdReq,
+        (void*)Descriptors,
+        sizeof(WNBD_UNMAP_DESCRIPTOR) * Count);
+
+    // TODO: validate unmap descriptors
+
+    handler->SendIoResponse(
+        RequestHandle, RequestType,
+        handler->MockStatus, NULL, 0);
+}
+
+void MockWnbdDaemon::SendIoResponse(
+    UINT64 RequestHandle,
+    WnbdRequestType RequestType,
+    WNBD_STATUS& Status,
+    PVOID DataBuffer,
+    UINT32 DataBufferSize
+) {
+    ASSERT_TRUE(WNBD_DEFAULT_MAX_TRANSFER_LENGTH >= DataBufferSize)
+        << "wnbd response too large";
+
+    WNBD_IO_RESPONSE Resp = { 0 };
+    Resp.RequestHandle = RequestHandle;
+    Resp.RequestType = RequestType;
+    Resp.Status = Status;
+
+    int err = WnbdSendResponse(
+        WnbdDisk,
+        &Resp,
+        DataBuffer,
+        DataBufferSize);
+
+    if (err && TerminateInProgress) {
+        // Suppress errors that might occur because of pending disk removals.
+        err = 0;
+    }
+
+    ASSERT_FALSE(err) << "unable to send wnbd response, error: "
+                      << GetLastError();
+}

--- a/tests/libwnbd_tests/mock_wnbd_daemon.h
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <mutex>
+#include <string.h>
+
+#include <wnbd.h>
+
+#include "request_log.h"
+
+#define IO_REQ_WORKERS 2
+#define WNBD_OWNER_NAME "WnbdTests"
+
+// The following byte will be used to fill read buffers,
+// allowing us to make assertions.
+#define READ_BYTE_CONTENT 0x0f
+#define WRITE_BYTE_CONTENT 0x0a
+
+class MockWnbdDaemon
+{
+private:
+    std::string InstanceName;
+    uint64_t BlockCount;
+    uint32_t BlockSize;
+    bool ReadOnly;
+    bool CacheEnabled;
+
+public:
+    MockWnbdDaemon(
+            std::string _InstanceName,
+            uint64_t _BlockCount, uint32_t _BlockSize,
+            bool _ReadOnly, bool _CacheEnabled)
+        : InstanceName(_InstanceName)
+        , BlockCount(_BlockCount)
+        , BlockSize(_BlockSize)
+        , ReadOnly(_ReadOnly)
+        , CacheEnabled(_CacheEnabled)
+    {
+    };
+    ~MockWnbdDaemon();
+
+    void Start();
+    // Wait for the daemon to stop, which normally happens when the driver
+    // passes the "Disconnect" request.
+    void Wait();
+    void Shutdown();
+
+    void SetStatus(WNBD_STATUS& Status) {
+        MockStatus = Status;
+    }
+
+    RequestLog ReqLog;
+
+private:
+    bool Started = false;
+    bool Terminated = false;
+    bool TerminateInProgress = false;
+    PWNBD_DISK WnbdDisk = nullptr;
+
+    WNBD_STATUS MockStatus = { 0 };
+
+    std::mutex ShutdownLock;
+
+    // WNBD IO entry points
+    static void Read(
+        PWNBD_DISK Disk,
+        UINT64 RequestHandle,
+        PVOID Buffer,
+        UINT64 BlockAddress,
+        UINT32 BlockCount,
+        BOOLEAN ForceUnitAccess);
+    static void Write(
+        PWNBD_DISK Disk,
+        UINT64 RequestHandle,
+        PVOID Buffer,
+        UINT64 BlockAddress,
+        UINT32 BlockCount,
+        BOOLEAN ForceUnitAccess);
+    static void Flush(
+        PWNBD_DISK Disk,
+        UINT64 RequestHandle,
+        UINT64 BlockAddress,
+        UINT32 BlockCount);
+    static void Unmap(
+        PWNBD_DISK Disk,
+        UINT64 RequestHandle,
+        PWNBD_UNMAP_DESCRIPTOR Descriptors,
+        UINT32 Count);
+
+    static constexpr WNBD_INTERFACE MockWnbdInterface =
+    {
+        Read,
+        Write,
+        Flush,
+        Unmap,
+    };
+
+    void SendIoResponse(
+        UINT64 RequestHandle,
+        WnbdRequestType RequestType,
+        WNBD_STATUS& Status,
+        PVOID DataBuffer,
+        UINT32 DataBufferSize
+    );
+};

--- a/tests/libwnbd_tests/packages.config
+++ b/tests/libwnbd_tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
+</packages>

--- a/tests/libwnbd_tests/packages.config
+++ b/tests/libwnbd_tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
-</packages>

--- a/tests/libwnbd_tests/pch.cpp
+++ b/tests/libwnbd_tests/pch.cpp
@@ -1,0 +1,5 @@
+//
+// pch.cpp
+//
+
+#include "pch.h"

--- a/tests/libwnbd_tests/pch.h
+++ b/tests/libwnbd_tests/pch.h
@@ -1,0 +1,7 @@
+//
+// pch.h
+//
+
+#pragma once
+
+#include "gtest/gtest.h"

--- a/tests/libwnbd_tests/pch.h
+++ b/tests/libwnbd_tests/pch.h
@@ -4,4 +4,11 @@
 
 #pragma once
 
+#include <iostream>
+
+#include <windows.h>
+
+#define _NTSCSI_USER_MODE_
+#include <scsi.h>
+
 #include "gtest/gtest.h"

--- a/tests/libwnbd_tests/request_log.cpp
+++ b/tests/libwnbd_tests/request_log.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+
+#include "request_log.h"
+
+void RequestLog::PushBack(const RequestLogEntry& Entry)
+{
+    std::unique_lock<std::mutex> Lock(ListLock);
+
+    auto RequestHandle = Entry.WnbdRequest.RequestHandle;
+
+    // Validate the request handle.
+    auto Result = RequestHandles.insert(RequestHandle);
+    ASSERT_TRUE(Result.second)
+        << "duplicate request handle received : "
+        << RequestHandle;
+
+    Entries.push_back(Entry);
+}
+
+void RequestLog::AddEntry(
+    WNBD_IO_REQUEST& WnbdRequest,
+    void* DataBuffer,
+    size_t DataBufferSize)
+{
+    void* BufferCopy = nullptr;
+    size_t BufferCopySize = 0;
+
+    if (DataBuffer && DataBufferSize > 0) {
+        BufferCopySize = DataBufferSize;
+        BufferCopy = malloc(BufferCopySize);
+        ASSERT_TRUE(BufferCopy)
+            << "couldn't allocate buffer, size: " << BufferCopySize;
+        memcpy(BufferCopy, DataBuffer, BufferCopySize);
+    }
+
+    RequestLogEntry Entry(WnbdRequest, BufferCopy, BufferCopySize);
+    PushBack(Entry);
+}
+
+bool RequestLog::HasEntry(
+    WNBD_IO_REQUEST& ExpWnbdRequest,
+    void* DataBuffer,
+    size_t DataBufferSize,
+    bool CheckDataBuffer)
+{
+    std::unique_lock<std::mutex> Lock(ListLock);
+
+    for (auto Entry: Entries) {
+        // Skip the request handle when comparing the requests
+        if (!memcmp((char*) &ExpWnbdRequest + sizeof(ExpWnbdRequest.RequestHandle),
+                   (char*) &Entry + sizeof(ExpWnbdRequest.RequestHandle),
+                   sizeof(WNBD_IO_REQUEST) - sizeof(ExpWnbdRequest.RequestHandle))) {
+            if (CheckDataBuffer && Entry.DataBuffer.get()) {
+                // Found a matching request, let's compare the buffers.
+                if (Entry.DataBufferSize != DataBufferSize) {
+                    continue;
+                }
+
+                if (memcmp(DataBuffer, Entry.DataBuffer.get(), DataBufferSize)) {
+                    continue;
+                }
+            }
+
+            // Found the expected request
+            return true;
+        }
+    }
+    return false;
+}

--- a/tests/libwnbd_tests/request_log.h
+++ b/tests/libwnbd_tests/request_log.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <mutex>
+#include <list>
+#include <string.h>
+
+#include <wnbd.h>
+
+struct RequestLogEntry
+{
+    WNBD_IO_REQUEST WnbdRequest;
+    std::shared_ptr<void> DataBuffer;
+    size_t DataBufferSize;
+
+    RequestLogEntry(
+            WNBD_IO_REQUEST _WnbdRequest,
+            void* _DataBuffer,
+            size_t _DataBufferSize)
+        : WnbdRequest(_WnbdRequest)
+        , DataBuffer(std::shared_ptr<void>(_DataBuffer, free))
+        , DataBufferSize(_DataBufferSize)
+    {}
+
+    RequestLogEntry(WNBD_IO_REQUEST _WnbdRequest)
+        : WnbdRequest(_WnbdRequest)
+        , DataBuffer(nullptr)
+        , DataBufferSize(0)
+    {}
+};
+
+struct RequestLog
+{
+    std::mutex ListLock;
+    std::list<RequestLogEntry> Entries;
+
+    // We'll ensure that there are no duplicate request handles
+    std::set<UINT64> RequestHandles;
+
+    void PushBack(const RequestLogEntry& Entry);
+
+    // Adds the specified Entry to the request log. If a buffer is specified,
+    // we'll make a copy.
+    void AddEntry(
+        WNBD_IO_REQUEST& WnbdRequest,
+        void* DataBuffer,
+        size_t DataBufferSize);
+
+    void AddEntry(WNBD_IO_REQUEST& WnbdRequest)
+    {
+        RequestLogEntry Entry(WnbdRequest, nullptr, 0);
+        PushBack(Entry);
+    }
+
+    bool HasEntry(
+        WNBD_IO_REQUEST& ExpWnbdRequest,
+        void* DataBuffer,
+        size_t DataBufferSize,
+        bool CheckDataBuffer);
+
+    // Searches for the specified request, ignoring the request handle.
+    bool HasEntry(
+        WNBD_IO_REQUEST& ExpWnbdRequest,
+        void* DataBuffer,
+        size_t DataBufferSize)
+    {
+        return HasEntry(ExpWnbdRequest, DataBuffer, DataBufferSize, true);
+    }
+
+    // Searches for the specified request, ignoring the request handle
+    // and data buffers.
+    bool HasEntry(
+        WNBD_IO_REQUEST& ExpWnbdRequest)
+    {
+        return HasEntry(ExpWnbdRequest, nullptr, 0, false);
+    }
+};

--- a/tests/libwnbd_tests/test.cpp
+++ b/tests/libwnbd_tests/test.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+
+TEST(TestCaseName, TestName) {
+  EXPECT_EQ(1, 1);
+  EXPECT_TRUE(true);
+}

--- a/tests/libwnbd_tests/test.cpp
+++ b/tests/libwnbd_tests/test.cpp
@@ -1,6 +1,415 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
 #include "pch.h"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
+#include "mock_wnbd_daemon.h"
+#include "utils.h"
+
+#include <stdexcept>
+
+static const uint64_t DefaultBlockCount = 1 << 20;
+static const uint64_t DefaultBlockSize = 512;
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    std::string WnbdLogLevelStr = GetEnv("WNBD_LOG_LEVEL");
+    try {
+        if (!WnbdLogLevelStr.empty()) {
+            int LogLevel = std::stoi(WnbdLogLevelStr);
+            WnbdSetLogLevel((WnbdLogLevel) LogLevel);
+        }
+    } catch (...) {
+        std::cerr << "invalid wnbd log level: " << WnbdLogLevelStr << std::endl;
+        exit(1);
+    }
+
+    return RUN_ALL_TESTS();
+}
+
+std::string GetNewInstanceName()
+{
+    auto TestInstance = ::testing::UnitTest::GetInstance();
+    auto TestName = std::string(TestInstance->current_test_info()->name());
+    return TestName + "-" + std::to_string(rand());
+}
+
+void TestMap(
+    uint64_t BlockCount = DefaultBlockCount,
+    uint32_t BlockSize = DefaultBlockSize,
+    bool ReadOnly = false,
+    bool CacheEnabled = true)
+{
+    auto InstanceName = GetNewInstanceName();
+
+    MockWnbdDaemon WnbdDaemon(
+        InstanceName,
+        BlockCount,
+        BlockSize,
+        ReadOnly,
+        CacheEnabled
+    );
+    WnbdDaemon.Start();
+
+    WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
+    NTSTATUS Status = WnbdShow(InstanceName.c_str(), &ConnectionInfo);
+    ASSERT_FALSE(Status) << "couldn't retrieve WNBD disk info";
+
+    EXPECT_EQ(
+        InstanceName,
+        std::string(ConnectionInfo.Properties.InstanceName));
+    EXPECT_EQ(
+        InstanceName,
+        std::string(ConnectionInfo.Properties.SerialNumber));
+    EXPECT_EQ(
+        std::string(WNBD_OWNER_NAME),
+        std::string(ConnectionInfo.Properties.Owner));
+    EXPECT_EQ(
+        BlockCount,
+        ConnectionInfo.Properties.BlockCount);
+    EXPECT_EQ(
+        BlockSize,
+        ConnectionInfo.Properties.BlockSize);
+    EXPECT_EQ(
+        _getpid(),
+        ConnectionInfo.Properties.Pid);
+
+    EXPECT_EQ(ReadOnly, ConnectionInfo.Properties.Flags.ReadOnly);
+    EXPECT_EQ(CacheEnabled, ConnectionInfo.Properties.Flags.FlushSupported);
+    EXPECT_EQ(CacheEnabled, ConnectionInfo.Properties.Flags.FUASupported);
+    EXPECT_TRUE(ConnectionInfo.Properties.Flags.UnmapSupported);
+    EXPECT_FALSE(ConnectionInfo.Properties.Flags.UseNbd);
+
+    // Should be called anyway by the destructor
+    WnbdDaemon.Shutdown();
+}
+
+TEST(TestMap, CacheEnabled) {
+    TestMap();
+}
+
+TEST(TestMap, CacheDisabled) {
+    TestMap(
+        DefaultBlockCount, DefaultBlockSize,
+        false, false);
+}
+
+TEST(TestMap, ReadOnly) {
+    TestMap(
+        DefaultBlockCount, DefaultBlockSize,
+        true);
+}
+
+TEST(TestMap, Map4kSector) {
+    TestMap(
+        DefaultBlockCount, 4096);
+}
+
+TEST(TestMap, Map2PBDisk) {
+    TestMap(
+        (2LL << 50) / DefaultBlockSize,
+        DefaultBlockSize);
+}
+
+void TestWrite(
+    uint64_t BlockCount = DefaultBlockCount,
+    uint32_t BlockSize = DefaultBlockSize,
+    bool CacheEnabled = true,
+    bool UseFUA = false)
+{
+    auto InstanceName = GetNewInstanceName();
+
+    MockWnbdDaemon WnbdDaemon(
+        InstanceName,
+        BlockCount,
+        BlockSize,
+        false, // writable
+        CacheEnabled
+    );
+    WnbdDaemon.Start();
+
+    WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
+    NTSTATUS Status = WnbdShow(InstanceName.c_str(), &ConnectionInfo);
+    ASSERT_FALSE(Status) << "couldn't retrieve WNBD disk info";
+
+    std::string DiskPath = GetDiskPath(InstanceName);
+    DWORD OpenFlags = FILE_ATTRIBUTE_NORMAL;
+    if (UseFUA) {
+        OpenFlags |= FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH;
+    }
+    HANDLE DiskHandle = CreateFileA(
+        DiskPath.c_str(),
+        GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        OpenFlags,
+        NULL);
+    ASSERT_NE(INVALID_HANDLE_VALUE, DiskHandle)
+        << "couldn't open disk: " << DiskPath
+        << ", error: " << WinStrError(GetLastError());
+    std::unique_ptr<void, decltype(&CloseHandle)> DiskHandleCloser(
+        DiskHandle, &CloseHandle);
+
+    int WriteBufferSize = 4 << 20;
+    std::unique_ptr<void, decltype(&free)> WriteBuffer(
+        malloc(WriteBufferSize), free);
+    ASSERT_TRUE(WriteBuffer.get()) << "couldn't allocate: " << WriteBufferSize;
+    memset(WriteBuffer.get(), WRITE_BYTE_CONTENT, WriteBufferSize);
+
+    WNBD_IO_REQUEST ExpWnbdRequest = { 0 };
+    ExpWnbdRequest.RequestType = WnbdReqTypeWrite;
+    ExpWnbdRequest.Cmd.Write.BlockAddress = 0;
+    ExpWnbdRequest.Cmd.Write.BlockCount = 1;
+    ExpWnbdRequest.Cmd.Write.ForceUnitAccess = UseFUA && CacheEnabled;
+    // We expect to be the first ones writing to this disk.
+    ASSERT_FALSE(WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest));
+
+    DWORD BytesWritten = 0;
+    // 1 block
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(BlockSize, BytesWritten);
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest, WriteBuffer.get(),
+        BlockSize));
+
+    // twice the maximum transfer size
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH,
+        &BytesWritten, NULL));
+    ASSERT_EQ(2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH, BytesWritten);
+
+    // We expect writes larger than the max transfer length to be fragmented.
+    // Here's the first fragment.
+    ExpWnbdRequest.Cmd.Write.BlockAddress = 1;
+    ExpWnbdRequest.Cmd.Write.BlockCount =
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(
+        ExpWnbdRequest, WriteBuffer.get(),
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+
+    // Second fragment
+    ExpWnbdRequest.Cmd.Write.BlockAddress +=
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ExpWnbdRequest.Cmd.Write.BlockCount =
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(
+        ExpWnbdRequest, WriteBuffer.get(),
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+
+    // Write one block at the end of the disk.
+    LARGE_INTEGER Offset;
+    Offset.QuadPart = (BlockCount - 1) * BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(
+        DiskHandle,
+        Offset,
+        NULL, FILE_BEGIN));
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(BlockSize, BytesWritten);
+
+    ExpWnbdRequest.Cmd.Write.BlockAddress = BlockCount - 1;
+    ExpWnbdRequest.Cmd.Write.BlockCount = 1;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest, WriteBuffer.get(),
+        BlockSize));
+
+    // Write passed the end of the disk, expecting a failure.
+    ASSERT_FALSE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(0, BytesWritten);
+
+    ASSERT_TRUE(FlushFileBuffers(DiskHandle));
+
+    ExpWnbdRequest = { 0 };
+    ExpWnbdRequest.RequestType = WnbdReqTypeFlush;
+    ASSERT_EQ(CacheEnabled, WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest));
+}
+
+TEST(TestWrite, CacheEnabled) {
+    TestWrite();
+}
+
+TEST(TestWrite, CacheDisabled) {
+    TestWrite(
+        DefaultBlockCount, DefaultBlockSize,
+        false);
+}
+
+TEST(TestWrite, Write4kSector) {
+    TestWrite(
+        DefaultBlockCount, 4096);
+}
+
+TEST(TestWrite, Write2PBDisk) {
+    TestWrite(
+        (2LL << 50) / DefaultBlockSize,
+        DefaultBlockSize);
+}
+
+TEST(TestWrite, FUACacheDisabled) {
+    TestWrite(
+        DefaultBlockCount, DefaultBlockSize,
+        false, true);
+}
+
+TEST(TestWrite, FUACacheEnabled) {
+    TestWrite(
+        DefaultBlockCount, DefaultBlockSize,
+        true, true);
+}
+
+void TestRead(
+    uint64_t BlockCount = DefaultBlockCount,
+    uint32_t BlockSize = DefaultBlockSize,
+    bool CacheEnabled = true)
+{
+    auto InstanceName = GetNewInstanceName();
+
+    MockWnbdDaemon WnbdDaemon(
+        InstanceName,
+        BlockCount,
+        BlockSize,
+        false, // writable
+        CacheEnabled
+    );
+    WnbdDaemon.Start();
+
+    WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
+    NTSTATUS Status = WnbdShow(InstanceName.c_str(), &ConnectionInfo);
+    ASSERT_FALSE(Status) << "couldn't retrieve WNBD disk info";
+
+    std::string DiskPath = GetDiskPath(InstanceName);
+    HANDLE DiskHandle = CreateFileA(
+        DiskPath.c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        NULL,
+        NULL);
+    ASSERT_NE(INVALID_HANDLE_VALUE, DiskHandle)
+        << "couldn't open disk: " << DiskPath
+        << ", error: " << WinStrError(GetLastError());
+    std::unique_ptr<void, decltype(&CloseHandle)> DiskHandleCloser(
+        DiskHandle, &CloseHandle);
+
+    int ReadBufferSize = 4 << 20;
+    std::unique_ptr<void, decltype(&free)> ReadBuffer(
+        malloc(ReadBufferSize), free);
+    ASSERT_TRUE(ReadBuffer.get()) << "couldn't allocate: " << ReadBufferSize;
+
+    int ExpReadBufferSize = 4 << 20;
+    std::unique_ptr<void, decltype(&free)> ExpReadBuffer(
+        malloc(ExpReadBufferSize), free);
+    ASSERT_TRUE(ExpReadBuffer.get()) << "couldn't allocate: " << ExpReadBufferSize;
+    memset(ExpReadBuffer.get(), READ_BYTE_CONTENT, ExpReadBufferSize);
+
+    DWORD BytesRead = 0;
+    // Clear read buffer
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    // 1 block
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(BlockSize, BytesRead);
+
+    WNBD_IO_REQUEST ExpWnbdRequest = { 0 };
+    ExpWnbdRequest.RequestType = WnbdReqTypeRead;
+    ExpWnbdRequest.Cmd.Read.BlockAddress = 0;
+    ExpWnbdRequest.Cmd.Read.BlockCount = 1;
+    // TODO: Windows doesn't set the FUA read flag, even when using
+    // FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH.
+    // We should consider using a passthrough scsi command to test read FUA.
+
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest));
+    ASSERT_FALSE(
+        memcmp(ReadBuffer.get(), ExpReadBuffer.get(), BlockSize));
+
+    // twice the maximum transfer size
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH,
+        &BytesRead, NULL));
+    ASSERT_EQ(2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH, BytesRead);
+
+    // We expect reads larger than the max transfer length to be fragmented.
+    // Here's the first fragment.
+    ExpWnbdRequest.Cmd.Read.BlockAddress = 1;
+    ExpWnbdRequest.Cmd.Read.BlockCount =
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(
+        ExpWnbdRequest, ReadBuffer.get(),
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+    ASSERT_FALSE(
+        memcmp(ReadBuffer.get(), ExpReadBuffer.get(),
+            WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+
+    // Second fragment
+    ExpWnbdRequest.Cmd.Read.BlockAddress +=
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ExpWnbdRequest.Cmd.Read.BlockCount =
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH / BlockSize;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(
+        ExpWnbdRequest, ReadBuffer.get(),
+        WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+    ASSERT_FALSE(
+        memcmp(ReadBuffer.get(), ExpReadBuffer.get(),
+            WNBD_DEFAULT_MAX_TRANSFER_LENGTH));
+
+    // Read one block at the end of the disk.
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    LARGE_INTEGER Offset;
+    Offset.QuadPart = (BlockCount - 1) * BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(
+        DiskHandle,
+        Offset,
+        NULL, FILE_BEGIN));
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(BlockSize, BytesRead);
+
+    ExpWnbdRequest.Cmd.Read.BlockAddress = BlockCount - 1;
+    ExpWnbdRequest.Cmd.Read.BlockCount = 1;
+    ASSERT_TRUE(WnbdDaemon.ReqLog.HasEntry(ExpWnbdRequest, ReadBuffer.get(),
+        BlockSize));
+    ASSERT_FALSE(
+        memcmp(ReadBuffer.get(), ExpReadBuffer.get(), BlockSize));
+
+    // Read passed the end of the disk, expecting a failure.
+    ASSERT_FALSE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(0, BytesRead);
+}
+
+TEST(TestRead, CacheEnabled) {
+    TestRead();
+}
+
+TEST(TestRead, CacheDisabled) {
+    TestRead(
+        DefaultBlockCount, DefaultBlockSize,
+        false);
+}
+
+TEST(TestRead, Read4kSector) {
+    TestRead(
+        DefaultBlockCount, 4096);
+}
+
+TEST(TestRead, Read2PBDisk) {
+    TestRead(
+        (2LL << 50) / DefaultBlockSize,
+        DefaultBlockSize);
 }

--- a/tests/libwnbd_tests/utils.cpp
+++ b/tests/libwnbd_tests/utils.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+
+#include "utils.h"
+
+std::string WinStrError(DWORD Err)
+{
+    LPSTR Msg = NULL;
+    DWORD MsgLen = ::FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        Err,
+        0,
+        (LPSTR)&Msg,
+        0,
+        NULL);
+
+    std::ostringstream MsgStream;
+    MsgStream << "(" << Err << ") ";
+    if (!MsgLen) {
+        MsgStream << "Unknown error";
+    }
+    else {
+        MsgStream << Msg;
+        ::LocalFree(Msg);
+    }
+    return MsgStream.str();
+}
+
+// Retrieves the disk path and waits for it to become available.
+std::string GetDiskPath(std::string InstanceName)
+{
+    DWORD TimeoutMs = 10 * 1000;
+    DWORD RetryInterval = 500;
+    LARGE_INTEGER StartTime, CurrTime, ElapsedMs, CounterFreq;
+    QueryPerformanceFrequency(&CounterFreq);
+    QueryPerformanceCounter(&StartTime);
+    ElapsedMs = { 0 };
+
+    do {
+        WNBD_CONNECTION_INFO ConnectionInfo = {0};
+        NTSTATUS Status = WnbdShow(InstanceName.c_str(), &ConnectionInfo);
+        if (Status) {
+            std::string Msg = "couln't retrieve WNBD disk info, error: " +
+                std::to_string(Status);
+            throw std::runtime_error(Msg);
+        }
+
+        QueryPerformanceCounter(&CurrTime);
+        ElapsedMs.QuadPart = CurrTime.QuadPart - StartTime.QuadPart;
+        ElapsedMs.QuadPart *= 1000;
+        ElapsedMs.QuadPart /= CounterFreq.QuadPart;
+
+        if (ConnectionInfo.DiskNumber != -1) {
+            std::string DiskPath = "\\\\.\\PhysicalDrive" + std::to_string(
+                ConnectionInfo.DiskNumber);
+
+            HANDLE DiskHandle = CreateFileA(
+                DiskPath.c_str(),
+                GENERIC_READ,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                NULL,
+                OPEN_EXISTING,
+                NULL,
+                NULL);
+            if (INVALID_HANDLE_VALUE != DiskHandle) {
+                // Disk available
+                CloseHandle(DiskHandle);
+                return DiskPath;
+            }
+
+            DWORD Status = GetLastError();
+            if (Status != ERROR_NO_SUCH_DEVICE &&
+                    Status != ERROR_FILE_NOT_FOUND) {
+                std::string Msg = "unable to open WNBD disk, error: " +
+                    std::to_string(Status);
+                throw std::runtime_error(Msg);
+            }
+        }
+
+        // Disk not available yet
+        if (TimeoutMs > ElapsedMs.QuadPart) {
+            Sleep(RetryInterval);
+        }
+    } while (TimeoutMs > ElapsedMs.QuadPart);
+
+    std::string Msg = "couln't retrieve WNBD disk info, timed out";
+    throw std::runtime_error(Msg);
+}
+
+void SetDiskWritable(std::string InstanceName)
+{
+    std::string DiskPath = GetDiskPath(InstanceName);
+
+    HANDLE DiskHandle = CreateFileA(
+        DiskPath.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        NULL,
+        NULL);
+    if (DiskHandle == INVALID_HANDLE_VALUE) {
+        std::string Msg = "couldn't open wnbd disk: " + InstanceName +
+            ", error: " + WinStrError(GetLastError());
+        throw std::runtime_error(Msg);
+    }
+    std::unique_ptr<void, decltype(&CloseHandle)> DiskHandleCloser(
+        DiskHandle, &CloseHandle);
+
+    SetDiskWritable(DiskHandle);
+}
+
+void SetDiskWritable(HANDLE DiskHandle)
+{
+    DWORD BytesReturned = 0;
+
+    SET_DISK_ATTRIBUTES attributes = {0};
+    attributes.Version = sizeof(attributes);
+    attributes.Attributes = 0; // clear read-only flag
+    attributes.AttributesMask = DISK_ATTRIBUTE_READ_ONLY;
+
+    BOOL Succeeded = DeviceIoControl(
+        DiskHandle,
+        IOCTL_DISK_SET_DISK_ATTRIBUTES,
+        (LPVOID) &attributes,
+        (DWORD) sizeof(attributes),
+        NULL,
+        0,
+        &BytesReturned,
+        NULL);
+    if (!Succeeded) {
+        std::string Msg = "couln't set wnbd disk as writable, error: " +
+            WinStrError(GetLastError());
+        throw std::runtime_error(Msg);
+    }
+}
+
+std::string GetEnv(std::string Name) {
+    char* ValBuff;
+    size_t ReqSize;
+
+    // VS throws warnings when using getenv, which it considers unsafe.
+    errno_t Err = getenv_s(&ReqSize, NULL, 0, Name.c_str());
+    if (Err && Err != ERANGE) {
+        std::string Msg = (
+            "couldn't retrieve env var: " + Name +
+            ". Error: " + std::to_string(Err));
+    }
+    if (!ReqSize) {
+        return "";
+    }
+
+    ValBuff = (char*) malloc(ReqSize);
+    if (!ValBuff) {
+        std::string Msg = "couldn't allocate: " + std::to_string(ReqSize);
+        throw std::runtime_error(Msg);
+    }
+
+    Err = getenv_s(&ReqSize, ValBuff, ReqSize, Name.c_str());
+    if (Err) {
+        free(ValBuff);
+
+        std::string Msg = (
+            "couldn't retrieve env var: " + Name +
+            ". Error: " + std::to_string(Err));
+        throw std::runtime_error(Msg);
+    }
+
+    std::string ValStr = std::string(ValBuff, ReqSize);
+    free(ValBuff);
+    return ValStr;
+}

--- a/tests/libwnbd_tests/utils.h
+++ b/tests/libwnbd_tests/utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string.h>
+
+#include <wnbd.h>
+
+// Converts a Windows error code to a string, including the error
+// description.
+std::string WinStrError(DWORD Err);
+
+// Retrieves the disk path and waits for it to become available.
+// Raises a runtime error upon failure.
+std::string GetDiskPath(std::string InstanceName);
+
+// Configures the specified disk as writable.
+// Raises a runtime error upon failure.
+void SetDiskWritable(std::string InstanceName);
+void SetDiskWritable(HANDLE DiskHandle);
+
+// Fetches the specified env variable, returning an empty string if
+// missing.
+// Raises a runtime error upon failure.
+std::string GetEnv(std::string Name);

--- a/vstudio/wnbd.sln
+++ b/vstudio/wnbd.sln
@@ -23,6 +23,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libwnbd", "..\libwnbd\libwn
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "build_deps", "build_deps.vcxproj", "{4EE28B36-2083-4FBA-88D7-FE60027B81BB}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libwnbd_tests", "..\tests\libwnbd_tests\libwnbd_tests.vcxproj", "{CB9F16AC-7578-4122-A364-A54AA527C426}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Analyze|x64 = Analyze|x64
@@ -64,6 +66,12 @@ Global
 		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Debug|x64.Build.0 = Debug|x64
 		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Release|x64.ActiveCfg = Release|x64
 		{4EE28B36-2083-4FBA-88D7-FE60027B81BB}.Release|x64.Build.0 = Release|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Analyze|x64.ActiveCfg = Debug|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Analyze|x64.Build.0 = Debug|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Debug|x64.ActiveCfg = Debug|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Debug|x64.Build.0 = Debug|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Release|x64.ActiveCfg = Release|x64
+		{CB9F16AC-7578-4122-A364-A54AA527C426}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add wnbd tests 

For testing purposes, we're adding a mock WNBD daemon which is
going to record the requests it receives and send predetermined
replies. It's based on our Ceph WnbdHandler.

This commit provides a few relatively simple test cases that:

* map a mock WNBD disk and validate the WnbdShow output
  * test invalid wnbd disk parameters
* cover various scenarios:
  * cache enabled/disabled
  * various sector sizes
  * various disk sizes, up to 2PB (we haven't defined a maximum
    disk size yet though)
* perform a few simple IO operations
  * read, write, flush
  * various offsets, including the beginning/end of the disk as well
    as invalid offsets, expecting an error
  * various IO sizes: one sector and then twice the maximum transfer
    size, expecting fragmented operations
  * check the returned data as well as the recorder requests, ensuring
    that flags such as FUA are set if required

While at it, we're fixing a few issues that were uncovered by the tests:

* libwnbd incorrect log formatting that can lead to a crash
* have WnbdWaitDispatcher wait for dispatcher threads instead of immediately returning once receiving the disconnect event
* temporarily enforce the sector size to be 512 due to issues that we're experiencing with larger sector sizes

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>