### PR TITLE
driver: fix scsi addressing

### DIFF
--- a/driver/driver.h
+++ b/driver/driver.h
@@ -10,14 +10,16 @@
 #include "version.h"
 
 // Maximum number of scsi targets per bus
-#define MAX_NUMBER_OF_SCSI_TARGETS       128
+#define WNBD_MAX_TARGETS_PER_BUS      128
 // Maximum number of luns per target
-#define MAX_NUMBER_OF_SCSI_LOGICAL_UNITS 1
-#define MAX_NUMBER_OF_SCSI_BUSES         1
+#define WNBD_MAX_LUNS_PER_TARGET      1
+// Maximum number of buses per target
+#define WNBD_MAX_BUSES_PER_ADAPTER    1
 // The maximum number of disks per WNBD adapter
-#define MAX_NUMBER_OF_DISKS (MAX_NUMBER_OF_SCSI_LOGICAL_UNITS * \
-                             MAX_NUMBER_OF_SCSI_TARGETS * \
-                             MAX_NUMBER_OF_SCSI_BUSES)
+#define WNBD_MAX_NUMBER_OF_DISKS \
+    (WNBD_MAX_LUNS_PER_TARGET * \
+     WNBD_MAX_TARGETS_PER_BUS * \
+     WNBD_MAX_BUSES_PER_ADAPTER)
 
 #define WNBD_INQUIRY_VENDOR_ID           "WNBD"
 #define WNBD_INQUIRY_PRODUCT_ID          "WNBD_DISK"

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -9,9 +9,15 @@
 
 #include "version.h"
 
+// Maximum number of scsi targets per bus
 #define MAX_NUMBER_OF_SCSI_TARGETS       128
+// Maximum number of luns per target
 #define MAX_NUMBER_OF_SCSI_LOGICAL_UNITS 1
 #define MAX_NUMBER_OF_SCSI_BUSES         1
+// The maximum number of disks per WNBD adapter
+#define MAX_NUMBER_OF_DISKS (MAX_NUMBER_OF_SCSI_LOGICAL_UNITS * \
+                             MAX_NUMBER_OF_SCSI_TARGETS * \
+                             MAX_NUMBER_OF_SCSI_BUSES)
 
 #define WNBD_INQUIRY_VENDOR_ID           "WNBD"
 #define WNBD_INQUIRY_PRODUCT_ID          "WNBD_DISK"

--- a/driver/scsi_driver_extensions.c
+++ b/driver/scsi_driver_extensions.c
@@ -95,12 +95,12 @@ WnbdHwFindAdapter(PVOID DeviceExtension,
     ConfigInfo->MaxNumberOfIO = WNBD_MAX_IN_FLIGHT_REQUESTS;
     ConfigInfo->NumberOfPhysicalBreaks = SP_UNINITIALIZED_VALUE;
     ConfigInfo->AlignmentMask = FILE_BYTE_ALIGNMENT;
-    ConfigInfo->NumberOfBuses = MAX_NUMBER_OF_SCSI_BUSES;
+    ConfigInfo->NumberOfBuses = WNBD_MAX_BUSES_PER_ADAPTER;
     ConfigInfo->ScatterGather = TRUE;
     ConfigInfo->Master = TRUE;
     ConfigInfo->CachesData = TRUE;
-    ConfigInfo->MaximumNumberOfTargets = MAX_NUMBER_OF_SCSI_TARGETS;
-    ConfigInfo->MaximumNumberOfLogicalUnits = MAX_NUMBER_OF_SCSI_LOGICAL_UNITS;
+    ConfigInfo->MaximumNumberOfTargets = WNBD_MAX_TARGETS_PER_BUS;
+    ConfigInfo->MaximumNumberOfLogicalUnits = WNBD_MAX_LUNS_PER_TARGET;
     ConfigInfo->WmiDataProvider = FALSE;
     ConfigInfo->SynchronizationModel = StorSynchronizeFullDuplex;
     ConfigInfo->VirtualDevice = TRUE;

--- a/libwnbd/libwnbd.cpp
+++ b/libwnbd/libwnbd.cpp
@@ -74,8 +74,12 @@ DWORD WnbdCreate(
         goto Exit;
     }
 
-    LogInfo("Mapped device. Connection id: %llu.",
-            Disk->ConnectionInfo.ConnectionId);
+    LogInfo("Mapped device. Connection id: %llu. "
+            "Bus: %d, target: %d, lun: %d.",
+            Disk->ConnectionInfo.ConnectionId,
+            Disk->ConnectionInfo.BusNumber,
+            Disk->ConnectionInfo.TargetId,
+            Disk->ConnectionInfo.Lun);
 
     *PDisk = Disk;
 

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -215,6 +215,9 @@ DWORD CmdShow(string InstanceName)
          << setw(25) << "Pid" << " : " <<  ConnInfo.Properties.Pid << endl
          << setw(25) << "DiskNumber" << " : " <<  ConnInfo.DiskNumber << endl
          << setw(25) << "PNPDeviceID" << " : " <<  to_string(wstring(ConnInfo.PNPDeviceID)) << endl
+         << setw(25) << "BusNumber" << " : " <<  ConnInfo.BusNumber << endl
+         << setw(25) << "TargetId" << " : " <<  ConnInfo.TargetId << endl
+         << setw(25) << "Lun" << " : " <<  ConnInfo.Lun << endl
          << endl;
 
     if (ConnInfo.Properties.Flags.UseNbd) {


### PR DESCRIPTION
This PR fixes the following SCSI address issues:

* avoid leaking addresses
* use the device list spinlock when accessing the address bitmap
* specify the right bus when notifying storport about bus changes
* use the right size when allocating the bitmap
* properly handle the addresses without making assumptions about the maximum number of luns and targets