### PR TITLE
tests: Disconnect tests

### DIFF
--- a/tests/libwnbd_tests/mock_wnbd_daemon.cc
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.cc
@@ -76,7 +76,8 @@ void MockWnbdDaemon::Shutdown()
         // We're requesting the disk to be removed but continue serving IO
         // requests until the driver sends us the "Disconnect" event.
         DWORD Ret = WnbdRemove(WnbdDisk, NULL);
-        ASSERT_FALSE(Ret) << "couldn't stop the wnbd dispatcher, err: " << Ret;
+        if (Ret && Ret != ERROR_FILE_NOT_FOUND)
+            ASSERT_FALSE(Ret) << "couldn't stop the wnbd dispatcher, err: " << Ret;
         Wait();
         Terminated = true;
     }
@@ -265,4 +266,8 @@ void MockWnbdDaemon::SendIoResponse(
 
 PWNBD_DISK MockWnbdDaemon::GetDisk() {
     return WnbdDisk;
+}
+
+void MockWnbdDaemon::TerminatingInProgress() {
+    TerminateInProgress = true;
 }

--- a/tests/libwnbd_tests/mock_wnbd_daemon.h
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.h
@@ -115,4 +115,6 @@ private:
     );
 public:
     PWNBD_DISK GetDisk();
+
+    void TerminatingInProgress();
 };


### PR DESCRIPTION
Added tests for removing WNBD disks, covering the following scenarios:
- soft remove w/ & w/o hard remove fallback
- hard remove
- soft removal time-out

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>