### PR TITLE
driver: Changed WnbdSetModeSense failure log message level to debug

### DIFF
--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -530,7 +530,7 @@ WnbdModeSense(_In_ PWNBD_DISK_DEVICE Device,
         !!Device->Properties.Flags.FUASupported,
         &Page, &Length);
     if (SRB_STATUS_SUCCESS != SrbStatus || NULL == Page) {
-        WNBD_LOG_INFO("Could not set mode sense. Status: %d", SrbStatus);
+        WNBD_LOG_DEBUG("Could not set mode sense. Status: %d", SrbStatus);
         goto Exit;
     }
 


### PR DESCRIPTION
When mapping a device, three consecutive info level log messages related to the failure of the WnbdSetModeSense function were being printed. This happend due to two unsupported mode pages, respectively the "Control" (0xAh) and "Informational Exceptions Control" (0x1Ch) mode pages. These two pages are related to task set management and error logging, which we don't support.

In order to make info level logging clearer, the WnbdSetModeSense failure logs have been set as debug level.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>