### PR TITLE
Add Windows version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ WNBD provides a low level API (the ``*Ioctl*`` functions), as well as a high lev
 includes the IO dispatching boilerplate. Please check the [public headers](include/) for
 more details.
 
+Requirements
+------------
+
+Windows 10.0.17763 (Windows Server 2019) is the minimum supported version. The WNBD driver
+will refuse to install on older unsupported versions.
+
 Submitting patches
 ------------------
 

--- a/driver/wnbd.inf
+++ b/driver/wnbd.inf
@@ -18,9 +18,9 @@ DefaultDestDir = 12
 wnbdSVM.ntamd64.Application = 11
 
 [Manufacturer]
-%wnbd%=wnbdSVM, NTamd64
+%wnbd%=wnbdSVM, NTamd64.10.0...17763
 
-[wnbdSVM.NTamd64]
+[wnbdSVM.NTamd64.10.0...17763]
 %WNBDVMDeviceDesc%=wnbdSVM_Device, %rootstr%
 
 [wnbdSVM_Device]

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -32,6 +32,11 @@ extern "C" {
 #define WNBD_HARDWAREID "root\\wnbd"
 #define WNBD_HARDWAREID_LEN sizeof(WNBD_HARDWAREID)
 
+// Minimum supported Windows version
+#define WNBD_REQ_WIN_VERSION_MAJOR 10
+#define WNBD_REQ_WIN_VERSION_MINOR 0
+#define WNBD_REQ_WIN_VERSION_BUILD 17763
+
 typedef enum
 {
     WnbdLogLevelCritical = 0,

--- a/libwnbd/utils.h
+++ b/libwnbd/utils.h
@@ -8,9 +8,14 @@
 
 #include <string>
 #include <guiddef.h>
+#include <optional>
 
 std::wstring to_wstring(const std::string& str);
 std::string to_string(const std::wstring& str);
 std::string win32_strerror(int err);
 
 std::string guid_to_string(GUID guid);
+
+std::optional<_OSVERSIONINFOEXW> GetWinVersion();
+bool CheckWindowsVersion(DWORD Major, DWORD Minor, DWORD BuildNumber);
+bool EnsureWindowsVersionSupported();

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -728,6 +728,10 @@ DWORD InstallDriver(
 
 DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired)
 {
+    if (!EnsureWindowsVersionSupported()) {
+        return ERROR_NOT_SUPPORTED;
+    }
+
     CHAR FullFileName[MAX_PATH];
     DWORD Status = 0, TempStatus = 0;
     BOOL InstallAttempted = FALSE;


### PR DESCRIPTION
This PR pins the minimum supported Windows version to 10.0.17763, which is the oldest tested version. The driver will refuse to install on unsupported Windows versions.

We're adding a hard requirement mostly because the driver has been reported to cause boot loops on unsupported Windows versions. For example, the WSK initialization causes a crash on 10.0.14393.

