### PR TITLE
Fix codeql static analysis warnings, required for driver certification

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:$WIN_VER
 
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 ADD https://chocolatey.org/install.ps1 C:\TEMP\choco-install.ps1
-ADD https://go.microsoft.com/fwlink/?linkid=2085767 C:\TEMP\wdksetup.exe
+ADD https://go.microsoft.com/fwlink/?linkid=2164149 C:\TEMP\wdksetup.exe
 
 # Let's be explicit about the shell that we're going to use.
 SHELL ["cmd", "/S", "/C"]
@@ -19,7 +19,7 @@ RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --add Microsoft.VisualStudio.Workload.MSBuildTools `
     --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.18362 `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
     --add Microsoft.VisualStudio.Component.VC.14.24.x86.x64 `
     --add Microsoft.VisualStudio.Component.VC.14.24.x86.x64.Spectre `
  || IF "%ERRORLEVEL%"=="3010" EXIT 0

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Visual Studio 2019 build tools or GUI
 ([Community version](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=16)
 or above)
 
-[Windows Driver Kit 1909](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk)
+[Windows Driver Kit 2104 (10.0.20348.0)](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk)
 
 As an alternative, you may use a [Docker Container](Dockerfile/Readme.md)
 that provides the build prerequisites.

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -30,6 +30,8 @@ NTSTATUS
 DriverEntry(PDRIVER_OBJECT DriverObject,
             PUNICODE_STRING RegistryPath)
 {
+    ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+
     /*
      * Register with ETW
      */

--- a/driver/nbd_dispatch.c
+++ b/driver/nbd_dispatch.c
@@ -256,7 +256,7 @@ NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device)
 
     if(!Reply.Error && IsReadSrb(Element->Srb)) {
         if (Element->DataLength > Device->ReadPreallocatedBufferLength) {
-            TempBuff = NbdMalloc(Element->DataLength);
+            TempBuff = NbdMallocZero(Element->DataLength);
             if (!TempBuff) {
                 Status = STATUS_INSUFFICIENT_RESOURCES;
                 WnbdDisconnectAsync(Device);

--- a/driver/nbd_protocol.c
+++ b/driver/nbd_protocol.c
@@ -110,7 +110,7 @@ NbdSendInfoRequest(_In_ INT Fd,
 PNBD_HANDSHAKE_RPL
 NbdReadHandshakeReply(_In_ INT Fd)
 {
-    PNBD_HANDSHAKE_RPL Retval = NbdMalloc(
+    PNBD_HANDSHAKE_RPL Retval = NbdMallocZero(
         sizeof(NBD_HANDSHAKE_RPL));
 
     if (!Retval) {
@@ -120,7 +120,6 @@ NbdReadHandshakeReply(_In_ INT Fd)
     }
 
     NTSTATUS error = STATUS_SUCCESS;
-    RtlZeroMemory(Retval, sizeof(NBD_HANDSHAKE_RPL));
     NbdReadExact(Fd, Retval, sizeof(*Retval), &error);
 
     Retval->Magic = RtlUlonglongByteSwap(Retval->Magic);
@@ -136,7 +135,7 @@ NbdReadHandshakeReply(_In_ INT Fd)
     }
     if (Retval->Datasize > 0) {
         INT NewSize = sizeof(NBD_HANDSHAKE_RPL) + Retval->Datasize;
-        PNBD_HANDSHAKE_RPL RetvalTemp = NbdMalloc(NewSize);
+        PNBD_HANDSHAKE_RPL RetvalTemp = NbdMallocZero(NewSize);
         if (!RetvalTemp) {
             WNBD_LOG_ERROR("Insufficient resources. Failed to allocate: %d bytes",
                 NewSize);
@@ -447,7 +446,7 @@ NbdWriteStat(INT Fd,
     UINT Needed = Length + sizeof(NBD_REQUEST);
     if (*PreallocatedLength < Needed) {
         PCHAR Buf = NULL;
-        Buf = NbdMalloc(Needed);
+        Buf = NbdMallocZero(Needed);
         if (NULL == Buf) {
             WNBD_LOG_ERROR("Insufficient resources. Failed to allocate: %ud bytes", Needed);
             Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/driver/nbd_protocol.h
+++ b/driver/nbd_protocol.h
@@ -94,7 +94,7 @@ __pragma(pack(pop))
 
 #define NBD_MEMPOOL_TAG      'pDBN'
 #define INIT_PASSWD           "NBDMAGIC"
-#define NbdMalloc(S) ExAllocatePoolWithTag(NonPagedPoolNx, S, NBD_MEMPOOL_TAG)
+#define NbdMallocZero(S) ExAllocatePoolZero(NonPagedPoolNx, S, NBD_MEMPOOL_TAG)
 #define NbdFree(S) ExFreePool(S)
 
 #ifdef __cplusplus

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -582,7 +582,7 @@ WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
     InterlockedIncrement64(&Device->Stats.TotalReceivedIORequests);
     InterlockedIncrement64(&Device->Stats.UnsubmittedIORequests);
 
-    PSRB_QUEUE_ELEMENT Element = (PSRB_QUEUE_ELEMENT)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(SRB_QUEUE_ELEMENT), 'DBNs');
+    PSRB_QUEUE_ELEMENT Element = (PSRB_QUEUE_ELEMENT)ExAllocatePoolZero(NonPagedPoolNx, sizeof(SRB_QUEUE_ELEMENT), 'DBNs');
     if (NULL == Element) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         Srb->SrbStatus = SRB_STATUS_ABORTED;

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -93,7 +93,7 @@
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WppEnabled>true</WppEnabled>
       <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
-      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;POOL_ZERO_DOWN_LEVEL_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WppTraceFunction>WnbdWppTrace{FLAGS=MYDRIVER_ALL_INFO}(LEVEL,MSG,...)</WppTraceFunction>
       <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
     </ClCompile>
@@ -112,7 +112,7 @@
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WppEnabled>true</WppEnabled>
       <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
-      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_WIN64;_AMD64_;AMD64;POOL_ZERO_DOWN_LEVEL_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WppTraceFunction>WnbdWppTrace{FLAGS=MYDRIVER_ALL_INFO}(LEVEL,MSG,...)</WppTraceFunction>
       <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
     </ClCompile>
@@ -127,6 +127,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\ksocket_wsk;..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;POOL_ZERO_DOWN_LEVEL_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(Platform)\$(Configuration)\ksocket_wsk.lib;libcntpr.lib;wdmsec.lib;$(DDK_LIB_PATH )netio.lib;$(DDK_LIB_PATH )storport.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
The CodeQL static analysis tests used for driver certification suggest us to replace the deprecated ExAllocatePoolWithTag function with ExAllocatePoolZero or ExAllocatePool2. The main reason is that those replacements will zero the allocated memory by default.

ExAllocatePool2 is only available on hosts >= 2004, while we intend to support older versions as well. For this reason, we'll use
ExAllocatePoolZero instead.

For Windows versions prior to 2004, we'll also have to define POOL_ZERO_DOWN_LEVEL_SUPPORT and call
ExInitializeDriverRuntime(DrvRtPoolNxOptIn) during driver initialization [1]. Apart from zero-ing the allocated memory, this
also marks it as non-executable by default.

We'll rename the Malloc and NbdMalloc ExAllocatePoolWithTag wrappers to MallocZero and NbdMallocZero to explicitly tell that the allocated memory is zero-ed out. At the same time, we're going to drop some RtlZeroMemory calls that become redundant.

[1] https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls#driver-updates-for-versions-of-windows-earlier-than-windows-10-version-2004

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>