### PR TITLE
driver: avoid absolute registry paths

### DIFF
--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -971,8 +971,13 @@ WnbdParseUserIOCTL(PWNBD_EXTENSION DeviceExtension,
         }
 
         GetOptCmd->Name[WNBD_MAX_OPT_NAME_LENGTH - 1] = L'\0';
+        // Save the input buffer so that it won't get overridden by our output, which uses
+        // the same IRP system buffer.
+        WCHAR OptName[WNBD_MAX_OPT_NAME_LENGTH] = { 0 };
+        RtlStringCbCopyW(OptName, sizeof(OptName), GetOptCmd->Name);
+
         PWNBD_OPTION_VALUE Value = (PWNBD_OPTION_VALUE) Irp->AssociatedIrp.SystemBuffer;
-        Status = WnbdGetDrvOpt(GetOptCmd->Name, Value, GetOptCmd->Persistent);
+        Status = WnbdGetDrvOpt(OptName, Value, GetOptCmd->Persistent);
 
         Irp->IoStatus.Information = sizeof(WNBD_OPTION_VALUE);
         break;

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -210,8 +210,6 @@ DWORD WnbdGetConnectionInfo(
 VOID WnbdSetLogger(LogMessageFunc Logger);
 VOID WnbdSetLogLevel(WnbdLogLevel LogLevel);
 
-DWORD WnbdRaiseDrvLogLevel(USHORT LogLevel);
-
 // Get libwnbd version.
 DWORD WnbdGetLibVersion(PWNBD_VERSION Version);
 DWORD WnbdGetDriverVersion(PWNBD_VERSION Version);

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -17,8 +17,6 @@
 
 #include <assert.h>
 
-#define WNBD_REGISTRY_KEY "SYSTEM\\CurrentControlSet\\Services\\wnbd"
-
 #define IOCTL_WNBD_PING 1
 #define IOCTL_WNBD_CREATE 2
 #define IOCTL_WNBD_REMOVE 3
@@ -270,7 +268,7 @@ WNBD_ASSERT_SZ_EQ(WNBD_IO_RESPONSE, 80);
 
 typedef enum
 {
-    WnbdOptUnknon = 0,
+    WnbdOptUnknown = 0,
     WnbdOptBool = 1,
     WnbdOptInt64 = 2,
     WnbdOptWstr = 3,

--- a/tests/libwnbd_tests/libwnbd_tests.vcxproj
+++ b/tests/libwnbd_tests/libwnbd_tests.vcxproj
@@ -36,6 +36,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="test_adapter_actions.cpp" />
     <ClCompile Include="test_disk_actions.cpp" />
     <ClCompile Include="test_io.cpp" />
     <ClCompile Include="utils.cpp" />

--- a/tests/libwnbd_tests/test_adapter_actions.cpp
+++ b/tests/libwnbd_tests/test_adapter_actions.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2023 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+#include "mock_wnbd_daemon.h"
+#include "utils.h"
+
+// The following test covers get/set/reset operations for both
+// ephemeral and persistent settings. Normally I'd avoid such a
+// long test, however it allows us to transition through various
+// scenarios.
+TEST(TestDrvOptions, TestGetSetDrvOptInt64) {
+    WNBD_OPTION_VALUE OptVal = { WnbdOptUnknown, 0 };
+
+    // 1. Reset the option
+    // -------------------
+    DWORD Status = WnbdResetDrvOpt("LogLevel", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    // retrieve persistent setting
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    // the persistent setting was cleared out, so we expect it
+    // to be unset.
+    ASSERT_EQ(ERROR_FILE_NOT_FOUND, Status)
+        << "couldn't retrieve persistent opt";
+
+    // retrieve current non-persistent setting
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // the default value
+    ASSERT_EQ(OptVal.Data.AsInt64, 1);
+
+    // 2. Set a non-persistent value
+    // -----------------------------
+    OptVal.Data.AsInt64 = 2;
+    Status = WnbdSetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    // no persistent setting yet
+    ASSERT_EQ(ERROR_FILE_NOT_FOUND, Status);
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    ASSERT_EQ(OptVal.Data.AsInt64, 2);
+
+    // 3. Set a persistent value
+    // -------------------------
+    OptVal.Data.AsInt64 = 3;
+    Status = WnbdSetDrvOpt("LogLevel", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    ASSERT_EQ(OptVal.Data.AsInt64, 3);
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    ASSERT_EQ(OptVal.Data.AsInt64, 3);
+
+    // 4. Set an ephemeral value, masking the persistent one
+    // -----------------------------------------------------
+    OptVal.Data.AsInt64 = 4;
+    Status = WnbdSetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // We've retrieved the original persistent value
+    ASSERT_EQ(OptVal.Data.AsInt64, 3);
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // We're now checking the current ephemeral value
+    ASSERT_EQ(OptVal.Data.AsInt64, 4);
+
+    // 5. Reset the ephemeral value
+    // ----------------------------
+    Status = WnbdResetDrvOpt("LogLevel", FALSE);
+    ASSERT_FALSE(Status) << "couldn't reset opt";
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // We've retrieved the original persistent value
+    ASSERT_EQ(OptVal.Data.AsInt64, 3);
+
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // We're now checking the current ephemeral value
+    ASSERT_EQ(OptVal.Data.AsInt64, 1);
+
+    // 5. Reset the persistent value, back to square one
+    // -------------------------------------------------
+    Status = WnbdResetDrvOpt("LogLevel", TRUE);
+    ASSERT_FALSE(Status) << "couldn't reset opt";
+
+    // retrieve persistent setting
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, TRUE);
+    // the persistent setting was cleared out, so we expect it
+    // to be unset.
+    ASSERT_EQ(ERROR_FILE_NOT_FOUND, Status)
+        << "couldn't retrieve persistent opt";
+
+    // retrieve current non-persistent setting
+    Status = WnbdGetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't retrieve opt";
+
+    ASSERT_EQ(OptVal.Type, WnbdOptInt64);
+    // the default value
+    ASSERT_EQ(OptVal.Data.AsInt64, 1);
+}
+
+TEST(TestDrvOptions, TestListOptions) {
+    // 1. Reset the option
+    // -------------------
+    DWORD Status = WnbdResetDrvOpt("LogLevel", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    Status = WnbdResetDrvOpt("DbgPrintEnabled", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    Status = WnbdResetDrvOpt("EtwLoggingEnabled", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    // 2. Modify some of the options
+    // -----------------------------
+    WNBD_OPTION_VALUE OptVal = { WnbdOptUnknown, 0 };
+
+    OptVal.Type = WnbdOptInt64;
+    OptVal.Data.AsInt64 = 3;
+    Status = WnbdSetDrvOpt("LogLevel", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    OptVal.Type = WnbdOptInt64;
+    OptVal.Data.AsInt64 = 2;
+    Status = WnbdSetDrvOpt("LogLevel", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    OptVal.Type = WnbdOptBool;
+    OptVal.Data.AsBool = FALSE;
+    Status = WnbdSetDrvOpt("DbgPrintEnabled", &OptVal, FALSE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    OptVal.Type = WnbdOptBool;
+    OptVal.Data.AsBool = TRUE;
+    Status = WnbdSetDrvOpt("EtwLoggingEnabled", &OptVal, TRUE);
+    ASSERT_FALSE(Status) << "couldn't set opt";
+
+    // 3. Check current options
+    // ------------------------
+    WnbdOptionList OptList = WnbdOptionList();
+    Status = OptList.Retrieve(FALSE);
+    ASSERT_FALSE(Status) << "couldn't list opt";
+
+    PWNBD_OPTION Option = OptList.GetOpt(L"LogLevel");
+    ASSERT_TRUE(Option) << "couldn't retrieve opt";
+    ASSERT_EQ(Option->Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Default.Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Default.Data.AsInt64, 1);
+    ASSERT_EQ(Option->Value.Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Value.Data.AsInt64, 2);
+
+    Option = OptList.GetOpt(L"DbgPrintEnabled");
+    ASSERT_TRUE(Option) << "couldn't retrieve opt";
+    ASSERT_EQ(Option->Type, WnbdOptBool);
+    ASSERT_EQ(Option->Default.Type, WnbdOptBool);
+    ASSERT_TRUE(Option->Default.Data.AsBool);
+    ASSERT_EQ(Option->Value.Type, WnbdOptBool);
+    ASSERT_FALSE(Option->Value.Data.AsBool);
+
+    Option = OptList.GetOpt(L"EtwLoggingEnabled");
+    ASSERT_TRUE(Option) << "couldn't retrieve opt";
+    ASSERT_EQ(Option->Type, WnbdOptBool);
+    ASSERT_EQ(Option->Default.Type, WnbdOptBool);
+    ASSERT_TRUE(Option->Default.Data.AsBool);
+    ASSERT_EQ(Option->Value.Type, WnbdOptBool);
+    ASSERT_TRUE(Option->Value.Data.AsBool);
+
+    // 4. Check persistent options
+    // ---------------------------
+    Status = OptList.Retrieve(TRUE);
+    ASSERT_FALSE(Status) << "couldn't list opt";
+
+    Option = OptList.GetOpt(L"LogLevel");
+    ASSERT_TRUE(Option) << "couldn't retrieve opt";
+    ASSERT_EQ(Option->Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Default.Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Default.Data.AsInt64, 1);
+    ASSERT_EQ(Option->Value.Type, WnbdOptInt64);
+    ASSERT_EQ(Option->Value.Data.AsInt64, 3);
+
+    Option = OptList.GetOpt(L"EtwLoggingEnabled");
+    ASSERT_TRUE(Option) << "couldn't retrieve opt";
+    ASSERT_EQ(Option->Type, WnbdOptBool);
+    ASSERT_EQ(Option->Default.Type, WnbdOptBool);
+    ASSERT_TRUE(Option->Default.Data.AsBool);
+    ASSERT_EQ(Option->Value.Type, WnbdOptBool);
+    ASSERT_TRUE(Option->Value.Data.AsBool);
+
+    Option = OptList.GetOpt(L"DbgPrintEnabled");
+    ASSERT_FALSE(Option)
+        << "the persistent list contains an option that isn't persistent";
+
+    // 5. Reset modified options
+    // -------------------------
+    Status = WnbdResetDrvOpt("LogLevel", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    Status = WnbdResetDrvOpt("DbgPrintEnabled", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+
+    Status = WnbdResetDrvOpt("EtwLoggingEnabled", TRUE);
+    ASSERT_TRUE(!Status || Status == ERROR_FILE_NOT_FOUND)
+        << "couldn't reset opt";
+}

--- a/tests/libwnbd_tests/utils.h
+++ b/tests/libwnbd_tests/utils.h
@@ -54,3 +54,22 @@ std::string GetEnv(std::string Name);
 // Returns a string containing the hex values of the byte array
 // received as parameter.
 std::string ByteArrayToHex(BYTE* arr, int length);
+
+// A simple wrapper on top of WNBD_OPTION_LIST, making it easier
+// to retrieve and parse.
+class WnbdOptionList {
+private:
+    PWNBD_OPTION_LIST OptionList = nullptr;
+    DWORD BuffSz = 0;
+
+public:
+    ~WnbdOptionList() {
+        if (OptionList) {
+            free(OptionList);
+            OptionList = nullptr;
+        }
+    }
+
+    DWORD Retrieve(BOOLEAN Persistent);
+    PWNBD_OPTION GetOpt(PWSTR Name);
+};


### PR DESCRIPTION
The driver certification tests fail if we access absolute registry paths, which means we can't directly use the registry path received by the DriverEntry function.

Instead, we'll have to use "IoOpenDriverRegistryKey" to open the registry key associated with this driver and then use Zw* functions instead of Rtl* when accessing the registry.

We'll go ahead and remove the WNBD_REGISTRY_KEY definition since it no longer applies. Wnbd users are expected to use libwnbd or DeviceIOControl in order to get/set driver settings, for example through wnbd-client.exe.

While at it, we're adding some tests for the driver settings. Those tests uncovered an issue affecting IOCTL_WNBD_GET_DRV_OPT requests, which is being addressed.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>