### PR TITLE
driver: track submitted requests

### DIFF
--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -247,6 +247,7 @@ NTSTATUS WnbdDispatchRequest(
         ExInterlockedInsertTailList(
             &Device->SubmittedReqListHead,
             &Element->Link, &Device->SubmittedReqListLock);
+        InterlockedIncrement64(&Device->Stats.TotalSubmittedIORequests);
         InterlockedIncrement64(&Device->Stats.PendingSubmittedIORequests);
         InterlockedDecrement64(&Device->Stats.UnsubmittedIORequests);
         // We managed to find a supported request, we can now exit the loop


### PR DESCRIPTION
Unlike the nbd dispatcher, the wnbd dispatcher doesn't increment the counter after forwarding IO requests.

This change ensures that submitted requets will be tracked accordingly, which is useful for debugging purposes.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>