### PR TITLE
driver: include semver instead of timestamp in INF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tags
 /vstudio/smvbuild.log
 /vstudio/smvstats.txt
 /vstudio/wnbd.DVL.XML
+/vstudio/wnbd.inf
 /vstudio/x64/
 /vstudio/sdv/
 /vstudiox64/

--- a/driver/wnbd.inf
+++ b/driver/wnbd.inf
@@ -9,6 +9,7 @@ Signature="$WINDOWS NT$"
 Class=SCSIAdapter
 ClassGUID={4D36E97B-E325-11CE-BFC1-08002BE10318}
 Provider=%wnbd%
+; The driver version is updated automatically using the git tag
 DriverVer = 02/17/2020,2.24.28.428
 CatalogFile = wnbd.cat
 PnpLockdown = 1

--- a/vstudio/build_deps.vcxproj
+++ b/vstudio/build_deps.vcxproj
@@ -35,7 +35,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 
   <Target Name="Build">
-    <Exec Command="powershell.exe -executionpolicy bypass -file &quot;$(SolutionDir)\generate_version_h.ps1&quot;" />
+    <Exec Command="powershell.exe -executionpolicy bypass -command &quot;$env:Path+=';$(WindowsSDK_ExecutablePath_x64)'; &amp; '$(SolutionDir)\generate_version_h.ps1'&quot;" />
     <Exec Command="powershell.exe -executionpolicy bypass -file &quot;$(SolutionDir)\..\get_dependencies.ps1&quot;" />
     <PropertyGroup>
       <MissingDepsError>Missing dependency: {0}. It was supposed to be retrieved using "get_dependencies.ps1".</MissingDepsError>

--- a/vstudio/driver.vcxproj
+++ b/vstudio/driver.vcxproj
@@ -106,6 +106,12 @@
     <DriverSign>
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
+    <Inf>
+      <SpecifyDriverVerDirectiveVersion>false</SpecifyDriverVerDirectiveVersion>
+    </Inf>
+    <Inf>
+      <SpecifyDriverVerDirectiveDate>false</SpecifyDriverVerDirectiveDate>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -123,6 +129,12 @@
     <DriverSign>
       <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
+    <Inf>
+      <SpecifyDriverVerDirectiveVersion>false</SpecifyDriverVerDirectiveVersion>
+    </Inf>
+    <Inf>
+      <SpecifyDriverVerDirectiveDate>false</SpecifyDriverVerDirectiveDate>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analyze|x64'">
     <ClCompile>
@@ -139,9 +151,15 @@
     <PostBuildEvent>
       <Command>powershell.exe -executionpolicy bypass -command $env:VCINSTALLDIR='$(VCInstallDir)'; cd $(SolutionDir); msbuild $(SolutionFileName) /p:Configuration=Release; msbuild $(ProjectFileName) /t:sdv /p:inputs='/check' /p:Configuration=Release /p:SolutionDir=$(SolutionDir); msbuild $(ProjectFileName) /p:Configuration=Release /P:RunCodeAnalysisOnce=True</Command>
     </PostBuildEvent>
+    <Inf>
+      <SpecifyDriverVerDirectiveVersion>false</SpecifyDriverVerDirectiveVersion>
+    </Inf>
+    <Inf>
+      <SpecifyDriverVerDirectiveDate>false</SpecifyDriverVerDirectiveDate>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Inf Include="..\driver\wnbd.inf" />
+    <Inf Include="..\vstudio\wnbd.inf" />
   </ItemGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />


### PR DESCRIPTION
When building the driver, stampinf is called with -v "*", which overrides the .inf version with "hours.minutes.seconds.milliseconds".

For this reason, the Windows device manager will show the wnbd build timestamp instead of the driver version, which can be confusing.

This change will call stampinf.exe explicitly using the wnbd SemVer version.

Since the inf file will be updated every time we do a build, we'll add it to .gitignore.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>