### PR TITLE
driver: fix persistent reservation checks

### DIFF
--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -413,6 +413,7 @@ WnbdCreateConnection(PWNBD_EXTENSION DeviceExtension,
         Device->Properties.Flags.UnmapSupported |= CHECK_NBD_SEND_TRIM(NbdFlags);
         Device->Properties.Flags.FlushSupported |= CHECK_NBD_SEND_FLUSH(NbdFlags);
         Device->Properties.Flags.FUASupported |= CHECK_NBD_SEND_FUA(NbdFlags);
+        Device->Properties.Flags.PersistResSupported = 0;
     }
 
     // TODO: fix the 4k sector size issue, potentially allowing even larger sector

--- a/driver/util.c
+++ b/driver/util.c
@@ -391,6 +391,7 @@ ValidateScsiRequest(
             return FALSE;
         }
         break;
+    case WnbdReqTypePersistResIn:
     case WnbdReqTypePersistResOut:
         if (!DevProps->Flags.PersistResSupported) {
              WNBD_LOG_DEBUG(


### PR DESCRIPTION
NBD connections are currently affected by "PERSISTENT RESERVATION IN" requests, which get queued despite the fact that NBD doesn't support this operation. Certain Windows operations end up waiting indefinitely for some persistent reservation commands.

This change fixes the persistent reservation support check, ensuring that those operations won't be queued unless supported by the backend.

We'll explicitly clear this flag for NBD connections.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>