### PR TITLE
driver: fix wsk initialization

### DIFF
--- a/driver/nbd_protocol.c
+++ b/driver/nbd_protocol.c
@@ -328,12 +328,6 @@ NbdOpenAndConnect(PCHAR HostName,
     Hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV;
     Hints.ai_protocol = IPPROTO_TCP;
 
-    DWORD Status = KsInitialize();
-    if (!NT_SUCCESS(Status)) {
-        WNBD_LOG_ERROR("Could not initialize WSK framework. Status: 0x%x.", Status);
-        return -1;
-    }
-
     char* PortName[12] = { 0 };
     RtlStringCbPrintfA((char*)PortName, sizeof(PortName), "%d", PortNumber);
 

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -381,6 +381,16 @@ WnbdCreateConnection(PWNBD_EXTENSION DeviceExtension,
     Device->SocketToClose = -1;
     Device->NbdSocket = -1;
     if (Properties->Flags.UseNbd) {
+        WNBD_LOG_DEBUG("Initializing WSK.");
+        // WnbdCreateConnection calls are synchronized
+        // using DeviceExtension->DeviceCreationLock.
+        Status = KsInitialize();
+        if (!NT_SUCCESS(Status)) {
+            WNBD_LOG_ERROR("Could not initialize WSK framework. "
+                           "Status: 0x%x.", Status);
+            goto Exit;
+        }
+
         WNBD_LOG_INFO("Connecting to NBD server: %s:%p. "
                       "Export name: %s.",
                       Properties->NbdProperties.Hostname,

--- a/driver/util.c
+++ b/driver/util.c
@@ -118,7 +118,6 @@ WnbdCleanupAllDevices(_In_ PWNBD_EXTENSION DeviceExtension)
     // for them to be removed after signaling the global device removal event.
     ExWaitForRundownProtectionRelease(&DeviceExtension->RundownProtection);
 
-    KsInitialize();
     KsDestroy();
 }
 

--- a/ksocket_wsk/ksocket.h
+++ b/ksocket_wsk/ksocket.h
@@ -8,6 +8,7 @@ extern "C" {
 
 typedef struct _KSOCKET KSOCKET, *PKSOCKET;
 
+// KsInitialize and KsDestroy calls must be synchronized
 NTSTATUS
 NTAPI
 KsInitialize(


### PR DESCRIPTION
According to the MS docs, each successful WskRegister call must be followed by exactly one WskDeregister call with the same registration structure. The same applies to WskCaptureProviderNPI and WskReleaseProviderNPI.

The issue is that we're calling the KsInitialize wrapper for every new nbd connection, however there's a single KsDestroy call in the HwFreeAdapterResources hook.

Another issue is that the KsDestroy call will be performed regardless of the previous KsInitialize status. We'd basically be destroying a structure that wasn't properly initialized. This seems to cause crashes on older Windows hosts that do not provide the WSK API that we're using.

This change fixes WSK initialization and cleanup.

Worth mentioning that we're most likely going to move the nbd client to userspace eventually, which will significantly simplify the driver and drop WSK usage (currently limited to NBD).

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>