### PR TITLE
driver: fix unicode initialization

### DIFF
--- a/driver/options.c
+++ b/driver/options.c
@@ -66,7 +66,8 @@ NTSTATUS WnbdGetPersistentOpt(
     PKEY_VALUE_PARTIAL_INFORMATION ValueInformation = (
         PKEY_VALUE_PARTIAL_INFORMATION) Buff;
 
-    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(Name);
+    UNICODE_STRING KeyName = { 0 };
+    RtlInitUnicodeString(&KeyName, Name);
     ULONG RequiredBufferSize = 0;
     NTSTATUS Status = ZwQueryValueKey(
         GlobalDrvRegHandle, &KeyName, KeyValuePartialInformation,
@@ -217,7 +218,8 @@ NTSTATUS WnbdSetDrvOpt(
     // We'll set the persistent value first. If that fails,
     // we won't set the runtime value.
     if (Persistent) {
-        UNICODE_STRING KeyName = RTL_CONSTANT_STRING(Name);
+        UNICODE_STRING KeyName = { 0 };
+        RtlInitUnicodeString(&KeyName, Name);
         Status = ZwSetValueKey(
             GlobalDrvRegHandle,
             &KeyName,
@@ -247,7 +249,8 @@ NTSTATUS WnbdResetDrvOpt(
     }
 
     if (Persistent) {
-        UNICODE_STRING KeyName = RTL_CONSTANT_STRING(Name);
+        UNICODE_STRING KeyName = { 0 };
+        RtlInitUnicodeString(&KeyName, Name);
         NTSTATUS Status = ZwDeleteValueKey(
             GlobalDrvRegHandle,
             &KeyName);


### PR DESCRIPTION
The RtlInitUnicodeString docs [1] suggest us to use the RTL_CONSTANT_STRING macro when initializing UNICODE_STRING structures. There's even the following reference:

  UNICODE_STRING RTL_CONSTANT_STRING(
    [in]  PCWSTR SourceString
  );

However, RTL_CONSTANT_STRING uses sizeof, so it's going to use the size of the pointer instead of the string length.

Visual studio will throw a warning but only for the "Analyze" builds:

  C:\workspace\wnbd\driver\options.c(250): warning C28132: Taking
  the size of pointer Name:  This will yield the size of a pointer
  (4 or 8), not the size of the object pointed to. Dereference the
  pointer, or if the size of a pointer was intended, use the
  pointer type or (void *) instead.

That being considered, we'll just use RtlInitUnicodeString instead.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>