### PR TITLE
tests: Drop MockWnbdDaemon excessive constructor params

### DIFF
--- a/tests/libwnbd_tests/mock_wnbd_daemon.h
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.h
@@ -14,7 +14,6 @@
 #include "request_log.h"
 
 #define IO_REQ_WORKERS 2
-#define WNBD_OWNER_NAME "WnbdTests"
 
 // The following byte will be used to fill read buffers,
 // allowing us to make assertions.
@@ -26,30 +25,10 @@
 class MockWnbdDaemon
 {
 private:
-    std::string InstanceName;
-    uint64_t BlockCount;
-    uint32_t BlockSize;
-    bool ReadOnly;
-    bool CacheEnabled;
-    bool UseCustomNaaIdentifier;
-    bool UseCustomDeviceSerial;
+    PWNBD_PROPERTIES WnbdProps;
 
 public:
-    MockWnbdDaemon(
-            std::string _InstanceName,
-            uint64_t _BlockCount, uint32_t _BlockSize,
-            bool _ReadOnly, bool _CacheEnabled,
-            bool _UseCustomNaaIdentifier = false,
-            bool _UseCustomDeviceSerial = false)
-        : InstanceName(_InstanceName)
-        , BlockCount(_BlockCount)
-        , BlockSize(_BlockSize)
-        , ReadOnly(_ReadOnly)
-        , CacheEnabled(_CacheEnabled)
-        , UseCustomNaaIdentifier(_UseCustomNaaIdentifier)
-        , UseCustomDeviceSerial(_UseCustomDeviceSerial)
-    {
-    };
+    MockWnbdDaemon(PWNBD_PROPERTIES _WnbdProps) : WnbdProps(_WnbdProps) {};
     ~MockWnbdDaemon();
 
     void Start();

--- a/tests/libwnbd_tests/utils.h
+++ b/tests/libwnbd_tests/utils.h
@@ -28,6 +28,8 @@
         GTEST_FATAL_FAILURE_("Expression mismatch: "#expression);   \
 }
 
+#define WNBD_OWNER_NAME "WnbdTests"
+
 static const uint64_t DefaultBlockCount = 1 << 20;
 static const uint64_t DefaultBlockSize = 512;
 
@@ -39,7 +41,7 @@ std::string WinStrError(DWORD Err);
 
 // Retrieves the disk path and waits for it to become available.
 // Raises a runtime error upon failure.
-std::string GetDiskPath(std::string InstanceName);
+std::string GetDiskPath(const char* InstanceName);
 
 // Configures the specified disk as writable.
 // Raises a runtime error upon failure.
@@ -73,3 +75,5 @@ public:
     DWORD Retrieve(BOOLEAN Persistent);
     PWNBD_OPTION GetOpt(PWSTR Name);
 };
+
+void GetNewWnbdProps(PWNBD_PROPERTIES);


### PR DESCRIPTION
The number of constructor arguments for MockWnbdDaemon was getting
out of hand, with some arguments only being necessary for one test.

With this commit, the constructor will only receive a pointer to a
WNBD_PROPERTIES structure that will contain all the properties set
accordingly for each test.

In every test, a default WNBD_PROPERTIES structure will be generated
using the GetNewWnbdProps function from utils.cpp, which receives a
reference to a WNBD_PROPERTIES structure, and for any custom
requirements, the values can be modified before calling the Start 
method of the MockWnbdDaemon class.

Signed-off-by: Stefan Chivu <schivu@cloudbasesolutions.com>