### PR TITLE
Add nbd tests

### DIFF
--- a/driver/nbd_dispatch.c
+++ b/driver/nbd_dispatch.c
@@ -290,7 +290,7 @@ NbdProcessDeviceThreadReplies(_In_ PWNBD_DISK_DEVICE Device)
         // TODO: do we care about the actual error?
         WNBD_LOG_INFO("NBD reply contains error: %llu", Reply.Error);
         Element->Srb->DataTransferLength = 0;
-        Element->Srb->SrbStatus = SRB_STATUS_ABORTED;
+        Element->Srb->SrbStatus = SRB_STATUS_ERROR;
     }
     else {
         Element->Srb->DataTransferLength = Element->DataLength;

--- a/driver/util.c
+++ b/driver/util.c
@@ -403,7 +403,9 @@ ValidateScsiRequest(
     return TRUE;
 }
 
-UCHAR SetSrbStatus(PVOID Srb, PWNBD_STATUS Status)
+void SetSrbStatus(
+    PSCSI_REQUEST_BLOCK Srb,
+    PWNBD_STATUS Status)
 {
     UCHAR SrbStatus = SRB_STATUS_ERROR;
     PSENSE_DATA SenseInfoBuffer = SrbGetSenseInfoBuffer(Srb);
@@ -435,7 +437,7 @@ UCHAR SetSrbStatus(PVOID Srb, PWNBD_STATUS Status)
         SrbStatus |= SRB_STATUS_AUTOSENSE_VALID;
     }
 
-    return SrbStatus;
+    Srb->SrbStatus = SrbStatus;
 }
 
 VOID CompleteRequest(

--- a/driver/util.h
+++ b/driver/util.h
@@ -82,7 +82,9 @@ BOOLEAN ValidateScsiRequest(
 
 #endif
 
-UCHAR SetSrbStatus(PVOID Srb, PWNBD_STATUS Status);
+void SetSrbStatus(
+    PSCSI_REQUEST_BLOCK Srb,
+    PWNBD_STATUS Status);
 
 static inline int
 ScsiOpToWnbdReqType(int ScsiOp)

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -373,7 +373,7 @@ NTSTATUS WnbdHandleResponse(
             Response->Status.ScsiStatus,
             Response->RequestHandle);
         Element->Srb->DataTransferLength = 0;
-        Element->Srb->SrbStatus = SetSrbStatus(Element->Srb, &Response->Status);
+        SetSrbStatus(Element->Srb, &Response->Status);
     }
     else {
         Element->Srb->DataTransferLength = Element->DataLength;

--- a/tests/libwnbd_tests/libwnbd_tests.vcxproj
+++ b/tests/libwnbd_tests/libwnbd_tests.vcxproj
@@ -25,11 +25,13 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClInclude Include="options.h" />
     <ClInclude Include="utils.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="mock_wnbd_daemon.cc" />
+    <ClCompile Include="options.cpp" />
     <ClCompile Include="request_log.cpp" />
     <ClCompile Include="test.cpp" />
     <ClCompile Include="pch.cpp">
@@ -39,6 +41,7 @@
     <ClCompile Include="test_adapter_actions.cpp" />
     <ClCompile Include="test_disk_actions.cpp" />
     <ClCompile Include="test_io.cpp" />
+    <ClCompile Include="test_nbd.cpp" />
     <ClCompile Include="utils.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -53,6 +56,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets" Condition="Exists('$(SolutionDir)\deps\boost_program_options-src.1.72.0.0\build\boost_program_options-src.targets')" />
     <Import Project="$(SolutionDir)\deps\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)\deps\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/tests/libwnbd_tests/mock_wnbd_daemon.cc
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.cc
@@ -88,11 +88,10 @@ void MockWnbdDaemon::Read(
 
     if (Disk->Properties.BlockCount < BlockAddress + BlockCount) {
         // Overflow
-        // TODO: consider moving this check to the driver.
         WnbdSetSense(
             &handler->MockStatus,
             SCSI_SENSE_ILLEGAL_REQUEST,
-            SCSI_ADSENSE_VOLUME_OVERFLOW);
+            SCSI_ADSENSE_ILLEGAL_BLOCK);
     } else {
         memset(Buffer, READ_BYTE_CONTENT, BlockCount * handler->WnbdProps->BlockSize);
     }

--- a/tests/libwnbd_tests/mock_wnbd_daemon.h
+++ b/tests/libwnbd_tests/mock_wnbd_daemon.h
@@ -7,9 +7,6 @@
 #pragma once
 
 #include <mutex>
-#include <string.h>
-
-#include <wnbd.h>
 
 #include "request_log.h"
 

--- a/tests/libwnbd_tests/options.cpp
+++ b/tests/libwnbd_tests/options.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+
+#include <vector>
+
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+using namespace std;
+
+po::variables_map Vm;
+
+void AddCommonOptions(
+    po::positional_options_description &PosOpts,
+    po::options_description &NamedOpts)
+{
+    NamedOpts.add_options()
+        ("log-level", po::value<DWORD>()->default_value(WnbdLogLevelWarning),
+            "Wnbd log level.")
+        ("help", po::bool_switch(), "Show usage.");
+}
+
+void AddNbdOptions(
+    po::positional_options_description &PosOpts,
+    po::options_description &NamedOpts)
+{
+    NamedOpts.add_options()
+        ("nbd-export-name", po::value<string>(),
+            "NBD export name")
+        ("nbd-hostname", po::value<string>(),
+            "NBD server hostname.")
+        ("nbd-port", po::value<DWORD>()->default_value(10809),
+            "NBD server port number. Default: 10809.");
+}
+
+void ParseOptions(int Argc, char** Argv)
+{
+    po::positional_options_description PosOpts;
+    po::options_description NamedOpts;
+
+    vector<string> Args;
+    Args.insert(Args.end(), Argv + 1, Argv + Argc);
+
+    try {
+        AddCommonOptions(PosOpts, NamedOpts);
+        AddNbdOptions(PosOpts, NamedOpts);
+
+        po::store(po::command_line_parser(Args)
+            .options(NamedOpts)
+            .positional(PosOpts)
+            .run(), Vm);
+        po::notify(Vm);
+    }
+    catch (po::required_option& e) {
+        cerr << "libwnbd_tests: " << e.what() << endl;
+        exit(-1);
+    }
+    catch (po::too_many_positional_options_error&) {
+        cerr << "libwnbd_tests: too many arguments" << endl;
+        exit(-1);
+    }
+    catch (po::error& e) {
+        cerr << "libwnbd_tests: " << e.what() << endl;
+        exit(-1);
+    }
+    catch (...) {
+        cerr << "libwnbd_tests: Caught unexpected exception." << endl << endl;
+        cerr << boost::current_exception_diagnostic_information() << endl;
+        exit(-1);
+    }
+}
+
+// TODO: consider using the helpers from usage.cpp if we ever end up having
+// an internal library reused between libwnbd, wnbd-client and the tests.
+void PrintHelp()
+{
+    char* Msg = R"HELP(
+Wnbd test parameters:
+  --log-level=[LOG_LEVEL]
+      Wnbd log level
+
+  --nbd-export-name=[NBD_EXPORT_NAME]
+      Existing NBD export to be used for NBD tests.
+      If unspecified, NBD tests will be skipped.
+  --nbd-hostname=[NBD_HOSTNAME]
+      The NBD server address.
+  --nbd-port=[NBD_PORT]
+      The NBD server port. Default: 10809.
+)HELP";
+
+    cout << Msg << endl;
+}

--- a/tests/libwnbd_tests/options.h
+++ b/tests/libwnbd_tests/options.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#pragma once
+
+#include <string>
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+
+extern po::variables_map Vm;
+
+// Make sure to pass the EXACT SAME type that was used when defining the option,
+// otherwise Boost will throw an exception.
+template <class T>
+T GetOpt(std::string Name, T DefaultVal = T())
+{
+    if (Vm.count(Name)) {
+        return Vm[Name].as<T>();
+    }
+    return DefaultVal;
+}
+
+void ParseOptions(int Argc, char** Argv);
+void PrintHelp();

--- a/tests/libwnbd_tests/pch.h
+++ b/tests/libwnbd_tests/pch.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#define _CRT_RAND_S
+#include <stdlib.h>
 #include <iostream>
+#include <string>
 
 #include <windows.h>
 
@@ -12,3 +15,5 @@
 #include <scsi.h>
 
 #include "gtest/gtest.h"
+
+#include <wnbd.h>

--- a/tests/libwnbd_tests/test.cpp
+++ b/tests/libwnbd_tests/test.cpp
@@ -7,21 +7,20 @@
 #include "pch.h"
 
 #include "utils.h"
+#include "options.h"
 
 int main(int argc, char **argv)
 {
+    if (argc > 1 && !strcmp(argv[1], "--help")) {
+        PrintHelp();
+    }
+
     ::testing::InitGoogleTest(&argc, argv);
 
-    std::string WnbdLogLevelStr = GetEnv("WNBD_LOG_LEVEL");
-    try {
-        if (!WnbdLogLevelStr.empty()) {
-            int LogLevel = std::stoi(WnbdLogLevelStr);
-            WnbdSetLogLevel((WnbdLogLevel) LogLevel);
-        }
-    } catch (...) {
-        std::cerr << "invalid wnbd log level: " << WnbdLogLevelStr << std::endl;
-        exit(1);
-    }
+    ParseOptions(argc, argv);
+
+    DWORD LogLevel = GetOpt<DWORD>("log-level");
+    WnbdSetLogLevel((WnbdLogLevel) LogLevel);
 
     return RUN_ALL_TESTS();
 }

--- a/tests/libwnbd_tests/test_io.cpp
+++ b/tests/libwnbd_tests/test_io.cpp
@@ -475,7 +475,9 @@ TEST(TestIoStats, TestIoStats) {
 
     WnbdGetUserspaceStats(WnbdDisk, &UserspaceStats);
     WnbdGetDriverStats(WnbdProps.InstanceName, &DriverStats);
-    EVENTUALLY(UserspaceStats.WriteErrors >= 1, 20, 100);
+    // The address check was moved to the driver, which is why
+    // we won't have a write error on the libwnbd side.
+    // EVENTUALLY(UserspaceStats.WriteErrors >= 1, 20, 100);
     EVENTUALLY(UserspaceStats.TotalRWRequests >= 3, 20, 100);
     EVENTUALLY(DriverStats.TotalReceivedIORequests >= 3, 20, 100);
     EVENTUALLY(DriverStats.TotalReceivedIOReplies >= 3, 20, 100);

--- a/tests/libwnbd_tests/test_io.cpp
+++ b/tests/libwnbd_tests/test_io.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2023 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
 #include "pch.h"
 #include "mock_wnbd_daemon.h"
 #include "utils.h"

--- a/tests/libwnbd_tests/test_nbd.cpp
+++ b/tests/libwnbd_tests/test_nbd.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2023 Cloudbase Solutions
+ *
+ * Licensed under LGPL-2.1 (see LICENSE)
+ */
+
+#include "pch.h"
+#include "mock_wnbd_daemon.h"
+#include "utils.h"
+#include "options.h"
+
+using namespace std;
+
+class NbdMapping {
+private:
+    PWNBD_DISK WnbdDisk = nullptr;
+
+public:
+    NbdMapping(PWNBD_PROPERTIES WnbdProps) {
+        string NbdExportName = GetOpt<string>("nbd-export-name");
+        string NbdHostName = GetOpt<string>("nbd-hostname");
+        DWORD NbdPort = GetOpt<DWORD>("nbd-port");
+
+        if (NbdExportName.empty()) {
+            throw runtime_error("missing NBD export");
+        }
+        if (NbdHostName.empty()) {
+            throw runtime_error("missing NBD server address");
+        }
+
+        // Fill the WNBD_PROPERTIES strucure
+        string InstanceName = GetNewInstanceName();
+        InstanceName.copy(WnbdProps->InstanceName, WNBD_MAX_NAME_LENGTH);
+        string(WNBD_OWNER_NAME).copy(WnbdProps->Owner, WNBD_MAX_OWNER_LENGTH);
+
+        WnbdProps->Flags.UseNbd = 1;
+
+        NbdHostName.copy(WnbdProps->NbdProperties.Hostname,
+                         WNBD_MAX_NAME_LENGTH);
+        NbdExportName.copy(WnbdProps->NbdProperties.ExportName,
+                           WNBD_MAX_NAME_LENGTH);
+        WnbdProps->NbdProperties.PortNumber = NbdPort;
+
+        DWORD Status = WnbdCreate(
+            WnbdProps, NULL,
+            NULL, &WnbdDisk);
+        if (Status) {
+            string Msg = "couln't create NBD mapping, error: " +
+                         to_string(Status);
+            throw runtime_error(Msg);
+        }
+    }
+
+    ~NbdMapping() {
+        if (WnbdDisk) {
+            DWORD Status = WnbdRemove(WnbdDisk, NULL);
+            if (Status && Status != ERROR_FILE_NOT_FOUND) {
+                ADD_FAILURE() << "couln't remove NBD mapping, error: "
+                              << Status;
+            }
+            WnbdClose(WnbdDisk);
+        }
+    }
+};
+
+bool CheckNbdParamsProvided() {
+    // TODO: GTEST_SKIP was included in gtest 1.9, yet Nuget only provides
+    // gtest 1.8. We should use GTEST_SKIP as soon as it becomes available.
+    if (GetOpt<string>("nbd-export-name").empty()) {
+        cout << "No NBD export provided, skipping NBD tests." << endl;
+        return false;
+    }
+    if (GetOpt<string>("nbd-hostname").empty()) {
+        cout << "No NBD server address provided, skipping NBD tests." << endl;
+        return false;
+    }
+    return true;
+}
+
+TEST(TestNbd, TestMap) {
+    if (!CheckNbdParamsProvided()) {
+        return;
+    }
+
+    WNBD_PROPERTIES WnbdProps = { 0 };
+    WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
+
+    {
+        NbdMapping Mapping(&WnbdProps);
+
+        NTSTATUS Status = WnbdShow(WnbdProps.InstanceName, &ConnectionInfo);
+        ASSERT_FALSE(Status) << "couldn't retrieve WNBD disk info";
+
+        EXPECT_EQ(
+            WnbdProps.InstanceName,
+            string(ConnectionInfo.Properties.InstanceName));
+        EXPECT_EQ(
+            WnbdProps.InstanceName,
+            string(ConnectionInfo.Properties.SerialNumber));
+        EXPECT_EQ(
+            string(WNBD_OWNER_NAME),
+            string(ConnectionInfo.Properties.Owner));
+        EXPECT_LT(0, ConnectionInfo.Properties.BlockCount);
+        EXPECT_LT(0, ConnectionInfo.Properties.BlockSize);
+        EXPECT_EQ(_getpid(), ConnectionInfo.Properties.Pid);
+
+        EXPECT_TRUE(ConnectionInfo.Properties.Flags.UseNbd);
+    }
+
+    // The mapping went out of scope, let's ensure that it got
+    // disconnected.
+    NTSTATUS Status = WnbdShow(WnbdProps.InstanceName, &ConnectionInfo);
+    EXPECT_EQ(ERROR_FILE_NOT_FOUND, Status);
+}
+
+TEST(TestNbd, TestIO) {
+    if (!CheckNbdParamsProvided()) {
+        return;
+    }
+
+    // 1. Connect the NBD disk and retrieve connection information
+    // -----------------------------------------------------------
+    WNBD_PROPERTIES WnbdProps = { 0 };
+    NbdMapping Mapping(&WnbdProps);
+
+    WNBD_CONNECTION_INFO ConnectionInfo = { 0 };
+    NTSTATUS Status = WnbdShow(WnbdProps.InstanceName, &ConnectionInfo);
+    ASSERT_FALSE(Status) << "couldn't retrieve WNBD disk info";
+
+    ASSERT_LT(0, ConnectionInfo.Properties.BlockCount);
+    EXPECT_LT(0, ConnectionInfo.Properties.BlockSize);
+
+    UINT64 BlockCount = ConnectionInfo.Properties.BlockCount;
+    UINT32 BlockSize = ConnectionInfo.Properties.BlockSize;
+
+    string DiskPath = GetDiskPath(WnbdProps.InstanceName);
+    DWORD OpenFlags = FILE_ATTRIBUTE_NORMAL |
+                      FILE_FLAG_NO_BUFFERING |
+                      FILE_FLAG_WRITE_THROUGH;
+    HANDLE DiskHandle = CreateFileA(
+        DiskPath.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        NULL,
+        OPEN_EXISTING,
+        OpenFlags,
+        NULL);
+    ASSERT_NE(INVALID_HANDLE_VALUE, DiskHandle)
+        << "couldn't open disk: " << DiskPath
+        << ", error: " << WinStrError(GetLastError());
+    unique_ptr<void, decltype(&CloseHandle)> DiskHandleCloser(
+        DiskHandle, &CloseHandle);
+
+    // 2. Write one block at the beginning of the disk and then read it
+    // ----------------------------------------------------------------
+    int WriteBufferSize = 4 << 20;
+    static_assert(4 << 20 == 2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH);
+
+    unique_ptr<void, decltype(&free)> WriteBuffer(
+        malloc(WriteBufferSize), free);
+    ASSERT_TRUE(WriteBuffer.get()) << "couldn't allocate: " << WriteBufferSize;
+
+    unsigned int Rand;
+    EXPECT_EQ(0, rand_s(&Rand));
+    memset(WriteBuffer.get(), Rand, WriteBufferSize);
+
+    int ReadBufferSize = 4 << 20;
+    unique_ptr<void, decltype(&free)> ReadBuffer(
+        malloc(ReadBufferSize), free);
+    ASSERT_TRUE(ReadBuffer.get()) << "couldn't allocate: " << ReadBufferSize;
+
+    DWORD BytesWritten = 0;
+    // 1 block
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(BlockSize, BytesWritten);
+
+    LARGE_INTEGER Offset = { 0 };
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+
+    DWORD BytesRead = 0;
+    // Clear the read buffer
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(BlockSize, BytesRead);
+    ASSERT_FALSE(memcmp(ReadBuffer.get(), WriteBuffer.get(),
+                 BytesRead));
+
+    // 3. Write twice the maximum transfer length and then verify the content
+    // ----------------------------------------------------------------------
+    EXPECT_EQ(0, rand_s(&Rand));
+    memset(WriteBuffer.get(), Rand, WriteBufferSize);
+
+    Offset.QuadPart = BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH,
+        &BytesWritten, NULL));
+    ASSERT_EQ(2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH, BytesWritten);
+
+    Offset.QuadPart = BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH, &BytesRead, NULL));
+    ASSERT_EQ(2 * WNBD_DEFAULT_MAX_TRANSFER_LENGTH, BytesRead);
+    ASSERT_FALSE(memcmp(ReadBuffer.get(), WriteBuffer.get(),
+                 BytesRead));
+
+    // 4. Write one block at the end of the disk and verify the content
+    // ----------------------------------------------------------------
+    EXPECT_EQ(0, rand_s(&Rand));
+    memset(WriteBuffer.get(), Rand, WriteBufferSize);
+
+    Offset.QuadPart = (BlockCount - 1) * BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+    ASSERT_TRUE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(BlockSize, BytesWritten);
+
+    Offset.QuadPart = (BlockCount - 1) * BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+    memset(ReadBuffer.get(), 0, ReadBufferSize);
+    ASSERT_TRUE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(BlockSize, BytesRead);
+    ASSERT_FALSE(memcmp(ReadBuffer.get(), WriteBuffer.get(),
+                 BytesRead));
+
+    // 5. Read/Write past the end of the disk, expecting a failure.
+    // --------------------------------------------------------------
+    Offset.QuadPart = BlockCount * BlockSize;
+    ASSERT_TRUE(SetFilePointerEx(DiskHandle, Offset, NULL, FILE_BEGIN));
+
+    ASSERT_FALSE(ReadFile(
+        DiskHandle, ReadBuffer.get(),
+        BlockSize, &BytesRead, NULL));
+    ASSERT_EQ(0, BytesRead);
+
+    ASSERT_FALSE(WriteFile(
+        DiskHandle, WriteBuffer.get(),
+        BlockSize, &BytesWritten, NULL));
+    ASSERT_EQ(0, BytesWritten);
+
+    ASSERT_TRUE(FlushFileBuffers(DiskHandle));
+}


### PR DESCRIPTION
We're adding some tests that exercise the NBD client functionality. The NBD export information can be specified using the following CLI parameters:

* --nbd-export-name
* --nbd-host
* --nbd-port (default: 10809)

If unspecified, the NBD tests will be skipped.

For consistency, we're replacing the WNBD_LOG_LEVEL env variable with a CLI parameter: --log-level.

We'll also address some issues that were brought up by the tests:

* updated srb status in case of nbd errors
* validate IO address on the driver side