### PR TITLE
Add connection list test

### DIFF
--- a/tests/libwnbd_tests/utils.h
+++ b/tests/libwnbd_tests/utils.h
@@ -76,4 +76,23 @@ public:
     PWNBD_OPTION GetOpt(PWSTR Name);
 };
 
+// A simple wrapper on top of WNBD_CONNECTION_LIST, making it easier
+// to retrieve and parse.
+class WnbdConnectionList {
+private:
+    PWNBD_CONNECTION_LIST ConnList = nullptr;
+    DWORD BuffSz = 0;
+
+public:
+    ~WnbdConnectionList() {
+        if (ConnList) {
+            free(ConnList);
+            ConnList = nullptr;
+        }
+    }
+
+    DWORD Retrieve();
+    PWNBD_CONNECTION_INFO GetConn(PSTR InstanceName);
+};
+
 void GetNewWnbdProps(PWNBD_PROPERTIES);


### PR DESCRIPTION
We're adding a new functional test that lists the current WNBD disk connections:

* it starts by creating two mappings
* retrieves the connection list
* ensures that the connection list contains the two expected mappings and validates the connection info
* removes the mappings and verifies that the updated connection list