### PR TITLE
driver: avoid logging read failures when closing nbd conn

### DIFF
--- a/driver/nbd_protocol.c
+++ b/driver/nbd_protocol.c
@@ -33,7 +33,9 @@ NbdReadExact(_In_ INT Fd,
             Length -= Result;
             Temp = Temp + Result;
         } else {
-            WNBD_LOG_WARN("Failed with : %d", Result);
+            if (Result) {
+                WNBD_LOG_WARN("Read failed, status: %d", Result);
+            }
             *error = STATUS_CONNECTION_DISCONNECTED;
             return -1;
         }


### PR DESCRIPTION
Whenever a NBD connection is closed, a warning message will be emitted.

We'll check the actual status code and avoid logging a warning in case of a graceful disconnect.