### PR TITLE
tests: cleanup mappings after failed negative tests

### DIFF
--- a/tests/libwnbd_tests/test_disk_actions.cpp
+++ b/tests/libwnbd_tests/test_disk_actions.cpp
@@ -115,6 +115,15 @@ void TestMapUnsupported(
         &WnbdProps,
         &ConnectionInfo,
         nullptr);
+    if (!err) {
+        // We were expecting this to fail. Let's clean up.
+        err = WnbdIoctlRemove(
+            AdapterHandle,
+            WnbdProps.InstanceName,
+            nullptr,
+            nullptr);
+        EXPECT_FALSE(err) << "Couldn't remove WNBD mapping";
+    }
     ASSERT_TRUE(err)
         << "WnbdCreate succeeded although it was expected to fail";
 }


### PR DESCRIPTION
One of the tests tries to create mappings with unsupported parameters, expecting a failure. If a mapping does get created, it won't be removed.

This change will ensure that such mappings get cleaned up.