### PR TITLE
Increase IO limit

### DIFF
--- a/driver/options.c
+++ b/driver/options.c
@@ -33,6 +33,8 @@ WNBD_OPTION WnbdDriverOptions[] = {
     WNBD_DEF_OPT(L"EtwLoggingEnabled", Bool, TRUE),
     WNBD_DEF_OPT(L"WppLoggingEnabled", Bool, FALSE),
     WNBD_DEF_OPT(L"DbgPrintEnabled", Bool, TRUE),
+    WNBD_DEF_OPT(L"MaxIOReqPerAdapter", Int64, WNBD_DEFAULT_MAX_IO_REQ_PER_ADAPTER),
+    WNBD_DEF_OPT(L"MaxIOReqPerLun", Int64, WNBD_DEFAULT_MAX_IO_REQ_PER_LUN),
 };
 DWORD WnbdOptionsCount = sizeof(WnbdDriverOptions) / sizeof(WNBD_OPTION);
 

--- a/driver/options.h
+++ b/driver/options.h
@@ -38,7 +38,9 @@ typedef enum {
     OptNewMappingsAllowed,
     OptEtwLoggingEnabled,
     OptWppLoggingEnabled,
-    OptDbgPrintEnabled
+    OptDbgPrintEnabled,
+    OptMaxIOReqPerAdapter,
+    OptMaxIOReqPerLun,
 } WNBD_OPT_KEY;
 
 extern WNBD_OPTION WnbdDriverOptions[];

--- a/driver/scsi_driver_extensions.h
+++ b/driver/scsi_driver_extensions.h
@@ -75,7 +75,7 @@ typedef struct _WNBD_DISK_DEVICE
 
 typedef struct _SRB_QUEUE_ELEMENT {
     LIST_ENTRY Link;
-    PSCSI_REQUEST_BLOCK Srb;
+    PVOID Srb;
     UINT64 StartingLbn;
     ULONG DataLength;
     BOOLEAN FUA;
@@ -115,6 +115,6 @@ WnbdHwResetBus(_In_ PVOID DeviceExtension,
 
 BOOLEAN
 WnbdHwStartIo(_In_ PVOID PDevExt,
-              _In_ PSCSI_REQUEST_BLOCK  PSrb);
+              _In_ PVOID PSrb);
 
 #endif

--- a/driver/scsi_function.h
+++ b/driver/scsi_function.h
@@ -11,22 +11,22 @@
 
 UCHAR
 WnbdAbortFunction(_In_ PVOID DeviceExtension,
-                  _In_ PSCSI_REQUEST_BLOCK Srb);
+                  _In_ PVOID Srb);
 
 UCHAR
 WnbdResetLogicalUnitFunction(_In_ PVOID DeviceExtension,
-                             _In_ PSCSI_REQUEST_BLOCK Srb);
+                             _In_ PVOID Srb);
 
 UCHAR
 WnbdResetDeviceFunction(_In_ PVOID DeviceExtension,
-                        _In_ PSCSI_REQUEST_BLOCK Srb);
+                        _In_ PVOID Srb);
 
 UCHAR
 WnbdExecuteScsiFunction(_In_ PVOID DeviceExtension,
-                        _In_ PSCSI_REQUEST_BLOCK Srb,
+                        _In_ PVOID Srb,
                         _Inout_ PBOOLEAN Complete);
 
 UCHAR
-WnbdPNPFunction(_In_ PSCSI_REQUEST_BLOCK Srb);
+WnbdPNPFunction(_In_ PVOID Srb);
 
 #endif

--- a/driver/scsi_operation.h
+++ b/driver/scsi_operation.h
@@ -13,5 +13,5 @@
 NTSTATUS
 WnbdHandleSrbOperation(_In_ PWNBD_EXTENSION DeviceExtension,
                        _In_ PWNBD_DISK_DEVICE ScsiDeviceExtension,
-                       _In_ PSCSI_REQUEST_BLOCK Srb);
+                       _In_ PVOID Srb);
 #endif

--- a/driver/scsi_trace.c
+++ b/driver/scsi_trace.c
@@ -11,7 +11,7 @@
 
 _Use_decl_annotations_
 PCHAR
-WnbdToStringSrbFunction(UCHAR SrbFunction)
+WnbdToStringSrbFunction(ULONG SrbFunction)
 {
     switch(SrbFunction) {
     CASE_STR(SRB_FUNCTION_EXECUTE_SCSI)

--- a/driver/scsi_trace.h
+++ b/driver/scsi_trace.h
@@ -10,7 +10,7 @@
 #include "common.h"
 
 PCHAR
-WnbdToStringSrbFunction(_In_ UCHAR SrbFunction);
+WnbdToStringSrbFunction(_In_ ULONG SrbFunction);
 
 PCHAR
 WnbdToStringSrbStatus(_In_ UCHAR SrbStatus);

--- a/driver/userspace.h
+++ b/driver/userspace.h
@@ -12,10 +12,6 @@
 #include "wnbd_ioctl.h"
 #include "scsi_driver_extensions.h"
 
-// TODO: make this configurable. 1024 is the Storport default.
-#define WNBD_MAX_IN_FLIGHT_REQUESTS 2048
-// TODO: make this configuragble. 255 is the Storport default.
-#define WNBD_MAX_IO_REQ_PER_LUN 512
 #define WNBD_PREALLOC_BUFF_SZ (WNBD_DEFAULT_MAX_TRANSFER_LENGTH + sizeof(NBD_REQUEST))
 
 NTSTATUS

--- a/driver/userspace.h
+++ b/driver/userspace.h
@@ -13,7 +13,9 @@
 #include "scsi_driver_extensions.h"
 
 // TODO: make this configurable. 1024 is the Storport default.
-#define WNBD_MAX_IN_FLIGHT_REQUESTS 1024
+#define WNBD_MAX_IN_FLIGHT_REQUESTS 2048
+// TODO: make this configuragble. 255 is the Storport default.
+#define WNBD_MAX_IO_REQ_PER_LUN 512
 #define WNBD_PREALLOC_BUFF_SZ (WNBD_DEFAULT_MAX_TRANSFER_LENGTH + sizeof(NBD_REQUEST))
 
 NTSTATUS

--- a/driver/util.h
+++ b/driver/util.h
@@ -64,9 +64,9 @@ WnbdFindDeviceByInstanceName(
     _In_ BOOLEAN Acquire);
 
 BOOLEAN
-IsReadSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
+IsReadSrb(_In_ PVOID Srb);
 BOOLEAN
-IsPerResInSrb(_In_ PSCSI_REQUEST_BLOCK Srb);
+IsPerResInSrb(_In_ PVOID Srb);
 
 VOID DisconnectSocket(_In_ PWNBD_DISK_DEVICE Device);
 VOID CloseSocket(_In_ PWNBD_DISK_DEVICE Device);
@@ -83,7 +83,7 @@ BOOLEAN ValidateScsiRequest(
 #endif
 
 void SetSrbStatus(
-    PSCSI_REQUEST_BLOCK Srb,
+    PVOID Srb,
     PWNBD_STATUS Status);
 
 static inline int

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -301,9 +301,11 @@ DWORD WnbdListDrvOpt(
 
 // Open the WNBD SCSI adapter device.
 DWORD WnbdOpenAdapter(PHANDLE Handle);
+DWORD WnbdGetAdapterDevInst(PDEVINST DeviceInst);
 DWORD WnbdIoctlPing(HANDLE Adapter, LPOVERLAPPED Overlapped);
 DWORD WnbdUninstallDriver(PBOOL RebootRequired);
 DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired);
+DWORD WnbdResetAdapter();
 
 // The "Overlapped" parameter used by WnbdIoctl* functions allows
 // asynchronous calls. If NULL, a valid overlapped structure is
@@ -392,6 +394,12 @@ DWORD WnbdIoctlSendResponse(
     PWNBD_IO_RESPONSE Response,
     PVOID DataBuffer,
     UINT32 DataBufferSize,
+    LPOVERLAPPED Overlapped);
+
+DWORD WnbdIoctlGetIOLimits(
+    HANDLE DiskHandle,
+    PDWORD LunMaxIoCount,
+    PDWORD AdapterMaxIoCount,
     LPOVERLAPPED Overlapped);
 
 static inline const CHAR* WnbdLogLevelToStr(WnbdLogLevel LogLevel) {

--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -306,6 +306,11 @@ DWORD WnbdIoctlPing(HANDLE Adapter, LPOVERLAPPED Overlapped);
 DWORD WnbdUninstallDriver(PBOOL RebootRequired);
 DWORD WnbdInstallDriver(CONST CHAR* FileName, PBOOL RebootRequired);
 DWORD WnbdResetAdapter();
+// Reset the adapter and retry if the device is busy.
+DWORD WnbdResetAdapterEx(DWORD TimeoutMs, DWORD RetryIntervalMs);
+// Sets "NewMappingsAllowed" to false and removes all the connected
+// WNBD disks.
+DWORD WnbdRemoveAllDisks(HANDLE AdapterHandle);
 
 // The "Overlapped" parameter used by WnbdIoctl* functions allows
 // asynchronous calls. If NULL, a valid overlapped structure is

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -50,6 +50,18 @@ static const GUID WNBD_GUID = {
 // however it's not. We shold rename it, dropping the "default" keyword.
 #define WNBD_DEFAULT_MAX_TRANSFER_LENGTH 2 * 1024 * 1024
 
+// The maximum number of outstanding IO operations per adapter.
+// 1000 is the Storport default.
+// Minimum: 1, maximum: WNBD_ABS_MAX_IO_REQ_PER_ADAPTER.
+#define WNBD_DEFAULT_MAX_IO_REQ_PER_ADAPTER 1000
+// The maximum number of outstanding IO operations per lun.
+// 255 is the Storport default.
+// Minimum: 1. maximum: WNBD_ABS_MAX_IO_REQ_PER_LUN.
+#define WNBD_DEFAULT_MAX_IO_REQ_PER_LUN 255
+// Out of caution, we're defining maximum values for the IO queue size.
+#define WNBD_ABS_MAX_IO_REQ_PER_ADAPTER 1024 * 128
+#define WNBD_ABS_MAX_IO_REQ_PER_LUN 1024
+
 // Only used for NBD connections, in which case the block size is optional.
 #define WNBD_DEFAULT_BLOCK_SIZE 512
 

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -31,7 +31,9 @@ EXPORTS
     WnbdUninstallDriver
     WnbdOpenAdapter
     WnbdResetAdapter
+    WnbdResetAdapterEx
     WnbdGetAdapterDevInst
+    WnbdRemoveAllDisks
 
     WnbdIoctlPing
     WnbdIoctlCreate

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -30,6 +30,8 @@ EXPORTS
     WnbdInstallDriver
     WnbdUninstallDriver
     WnbdOpenAdapter
+    WnbdResetAdapter
+    WnbdGetAdapterDevInst
 
     WnbdIoctlPing
     WnbdIoctlCreate
@@ -45,3 +47,5 @@ EXPORTS
     WnbdIoctlSetDrvOpt
     WnbdIoctlResetDrvOpt
     WnbdIoctlListDrvOpt
+
+    WnbdIoctlGetIOLimits

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -516,7 +516,7 @@ Exit:
     return Status;
 }
 
-DWORD RemoveAllWnbdDisks(HANDLE AdapterHandle)
+DWORD WnbdRemoveAllDisks(HANDLE AdapterHandle)
 {
     DWORD BufferSize = 0;
     DWORD Status = 0;
@@ -613,7 +613,7 @@ DWORD RemoveAllWnbdDevices(PBOOL RebootRequired) {
 
         Found = TRUE;
         if (DeviceAvailable) {
-            TempStatus = RemoveAllWnbdDisks(AdapterHandle);
+            TempStatus = WnbdRemoveAllDisks(AdapterHandle);
             Status = TempStatus ? TempStatus : Status;
         }
         else {

--- a/libwnbd/wnbd_ioctl.cpp
+++ b/libwnbd/wnbd_ioctl.cpp
@@ -803,6 +803,9 @@ Exit:
             LogError("Driver rollback failed. Error: %d.", Status);
         }
     }
+    if (DeviceInfoList != INVALID_HANDLE_VALUE) {
+        SetupDiDestroyDeviceInfoList(DeviceInfoList);
+    }
 
     return Status;
 }

--- a/tests/libwnbd_tests/utils.h
+++ b/tests/libwnbd_tests/utils.h
@@ -19,8 +19,8 @@
     while (_retry_attempts--) {                                     \
         if (expression) {                                           \
             ok = true;                                              \
-        }                                                           \
-        else {                                                      \
+            break;                                                  \
+        } else {                                                    \
             Sleep(retry_interval_ms);                               \
         }                                                           \
     }                                                               \

--- a/wnbd-client/client.cpp
+++ b/wnbd-client/client.cpp
@@ -338,6 +338,30 @@ DWORD execute_uninstall(const po::variables_map& vm)
     return CmdUninstall();
 }
 
+void get_reset_adapter_args(
+    po::positional_options_description &positonal_opts,
+    po::options_description &named_opts)
+{
+    named_opts.add_options()
+        ("hard-disconnect-mappings", po::bool_switch(),
+         "Forcefully removes existing disk mappings.")
+        ("reset-timeout",
+            po::value<DWORD>()->default_value(10),
+            "Adapter reset timeout in seconds. The PnP reset request can be "
+            "vetoed if the device is still in use. Default: 10s.")
+        ("reset-retry-interval",
+            po::value<DWORD>()->default_value(1),
+            "Adapter reset retry interval in seconds. Default: 1s.");
+}
+
+DWORD execute_reset_adapter(const po::variables_map &vm)
+{
+    return CmdResetAdapter(
+        safe_get_param<bool>(vm, "hard-disconnect-mappings"),
+        safe_get_param<DWORD>(vm, "reset-timeout"),
+        safe_get_param<DWORD>(vm, "reset-retry-interval"));
+}
+
 Client::Command commands[] = {
     Client::Command(
         "version", {"-v"}, "Get the client, library and driver version.",
@@ -381,4 +405,8 @@ Client::Command commands[] = {
         "uninstall-driver", {}, "Hard remove all disk mappings and adapters"
                                 " and uninstall all WNBD driver instances.",
         execute_uninstall),
+    Client::Command(
+        "reset-adapter", {}, "Resets the WNBD adapter using PnP. Existing "
+                             "disk mappings need to be removed.",
+        execute_reset_adapter, get_reset_adapter_args),
 };

--- a/wnbd-client/cmd.h
+++ b/wnbd-client/cmd.h
@@ -74,3 +74,9 @@ CmdUninstall();
 
 DWORD
 CmdInstall(std::string FileName);
+
+DWORD
+CmdResetAdapter(
+    BOOLEAN HardRemoveMappings,
+    DWORD ResetTimeout,
+    DWORD ResetRetryInterval);


### PR DESCRIPTION
Right now, we're limited to 255 requests per LUN and 1000 requests per adapter, which might be insufficient for large workloads.

We're going to make this configurable. Note that in order to be allowed to increase the limit, we need to support extended SRBs. This means that instead of accessing SRBs directly, we'll need to use the DDK helpers, which can handle both standard SRBs (``SCSI_REQUEST_BLOCK``) and extended SRBs (``STORAGE_REQUEST_BLOCK``).

Resetting the adapter is required in order for the new IO limits to be applied. For convenience, we're also adding a command that can be used to hard remove all attachments and then reset the adapter.

Sample:

```
PS C:\> wnbd-client.exe show rbd/test_4g_5
Connection info
...
MaxIOReqPerLun            : 255
MaxIOReqPerAdapter        : 1000

PS C:\> wnbd-client set-opt MaxIOReqPerLun 512 --persistent
PS C:\> wnbd-client set-opt MaxIOReqPerAdapter 8192 --persistent
PS C:\> Stop-Service ceph-rbd

PS C:\> wnbd-client.exe reset-adapter --hard-disconnect-mappings

PS C:\> Stop-Service ceph-rbd

PS C:\> wnbd-client.exe show rbd/test_4g_5
Connection info
...
MaxIOReqPerLun            : 512
MaxIOReqPerAdapter        : 8192
```
