### PR TITLE
Drop build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 Windows Network Block Device (WNBD)
 ===================================
 
-Build Status:
--------------
-
-![Build status](https://github.com/cloudbase/wnbd/actions/workflows/pr-tests.yaml/badge.svg)
-
 What is WNBD?
 -------------
 


### PR DESCRIPTION
The Github Action build status badge is broken:
https://github.com/orgs/community/discussions/14980

We're getting the "no status" message, so we'll go ahead and remove it for now so that we won't confuse users.