### PR TITLE
Detect and remove stale connections

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -77,7 +77,7 @@ jobs:
           wnbd-client install-driver --debug
           vstudio\x64\${{ matrix.configuration }}\driver\wnbd.inf
       - name: "Install qemu, used for NBD tests"
-        run: choco install qemu
+        run: choco install qemu --version 2023.4.24 -y
       - name: "Add qemu directory to env PATH"
         run: Add-Content $env:GITHUB_PATH 'C:\Program Files\qemu'
       - name: "Create qcow2 image, used for NBD"

--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ WppLoggingEnabled  : false (Default: false)
 DbgPrintEnabled    : true (Default: true)
 MaxIOReqPerAdapter : 1000 (Default: 1000)
 MaxIOReqPerLun     : 255 (Default: 255)
+RemoveStaleConnections : true (Default: true)
+StaleReqTimeoutMs      : 15000 (Default: 15000)
+StaleConnTimeoutMs     : 60000 (Default: 60000)
 ```
 
 Use the following command to configure an option. If the setting should persist
@@ -414,6 +417,25 @@ start-service ceph-rbd
 # Verify the updated IO limits
 wnbd-client.exe show $mapping
 ```
+
+Stale IO daemon detection
+-------------------------
+
+In some situations, the host can become unresponsive if there are stale IO
+connections.
+
+To avoid this, WNBD automatically detects and removes stale connections. This
+behavior along with the timeouts are configurable using the following settings:
+
+```
+RemoveStaleConnections : true (Default: true)
+StaleReqTimeoutMs      : 15000 (Default: 15000)
+StaleConnTimeoutMs     : 60000 (Default: 60000)
+```
+
+The driver considers the connection to be stale if there are aborted requests
+older than ``StaleReqTimeoutMs`` and if there hasn't been any IO reply since
+``StaleConnTimeoutMs``.
 
 Limitations
 ===========

--- a/driver/options.c
+++ b/driver/options.c
@@ -35,6 +35,9 @@ WNBD_OPTION WnbdDriverOptions[] = {
     WNBD_DEF_OPT(L"DbgPrintEnabled", Bool, TRUE),
     WNBD_DEF_OPT(L"MaxIOReqPerAdapter", Int64, WNBD_DEFAULT_MAX_IO_REQ_PER_ADAPTER),
     WNBD_DEF_OPT(L"MaxIOReqPerLun", Int64, WNBD_DEFAULT_MAX_IO_REQ_PER_LUN),
+    WNBD_DEF_OPT(L"RemoveStaleConnections", Bool, TRUE),
+    WNBD_DEF_OPT(L"StaleReqTimeoutMs", Int64, WNBD_DEFAULT_STALE_REQ_TIMEOUT_MS),
+    WNBD_DEF_OPT(L"StaleConnTimeoutMs", Int64, WNBD_DEFAULT_STALE_CONN_TIMEOUT_MS),
 };
 DWORD WnbdOptionsCount = sizeof(WnbdDriverOptions) / sizeof(WNBD_OPTION);
 

--- a/driver/options.h
+++ b/driver/options.h
@@ -41,6 +41,9 @@ typedef enum {
     OptDbgPrintEnabled,
     OptMaxIOReqPerAdapter,
     OptMaxIOReqPerLun,
+    OptRemoveStaleConnections,
+    OptStaleReqTimeoutMs,
+    OptStaleConnTimeoutMs,
 } WNBD_OPT_KEY;
 
 extern WNBD_OPTION WnbdDriverOptions[];

--- a/driver/scsi_driver_extensions.h
+++ b/driver/scsi_driver_extensions.h
@@ -68,6 +68,8 @@ typedef struct _SRB_QUEUE_ELEMENT {
     UINT64 Tag;
     BOOLEAN Aborted;
     BOOLEAN Completed;
+    // Retrieved using KeQueryInterruptTime.
+    UINT64 ReqTimestamp;
 } SRB_QUEUE_ELEMENT, * PSRB_QUEUE_ELEMENT;
 
 SCSI_ADAPTER_CONTROL_STATUS

--- a/driver/scsi_function.c
+++ b/driver/scsi_function.c
@@ -15,7 +15,8 @@
 #include "userspace.h"
 
 UCHAR DrainDeviceQueues(PVOID DeviceExtension,
-                        PVOID Srb)
+                        PVOID Srb,
+                        BOOLEAN CheckStaleConn)
 
 {
     ASSERT(Srb);
@@ -44,8 +45,8 @@ UCHAR DrainDeviceQueues(PVOID DeviceExtension,
         goto Exit;
     }
 
-    DrainDeviceQueue(Device, FALSE);
-    DrainDeviceQueue(Device, TRUE);
+    DrainDeviceQueue(Device, FALSE, CheckStaleConn);
+    DrainDeviceQueue(Device, TRUE, CheckStaleConn);
 
     WnbdReleaseDevice(Device);
     SrbStatus = SRB_STATUS_SUCCESS;
@@ -62,7 +63,7 @@ WnbdAbortFunction(_In_ PVOID DeviceExtension,
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
-    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
+    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb, TRUE);
 
     return SrbStatus;
 }
@@ -75,7 +76,7 @@ WnbdResetLogicalUnitFunction(PVOID DeviceExtension,
     ASSERT(Srb);
     ASSERT(DeviceExtension);
 
-    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb);
+    UCHAR SrbStatus = DrainDeviceQueues(DeviceExtension, Srb, TRUE);
 
     return SrbStatus;
 }

--- a/driver/scsi_operation.c
+++ b/driver/scsi_operation.c
@@ -579,6 +579,7 @@ WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
 {
     NTSTATUS Status = STATUS_SUCCESS;
 
+    Device->Stats.LastReceivedReqTimestamp = KeQueryInterruptTime();
     InterlockedIncrement64(&Device->Stats.TotalReceivedIORequests);
     InterlockedIncrement64(&Device->Stats.UnsubmittedIORequests);
 
@@ -590,6 +591,7 @@ WnbdPendElement(_In_ PWNBD_EXTENSION DeviceExtension,
     }
     WNBD_LOG_DEBUG("Queuing Element, SRB=%p", Srb);
 
+    Element->ReqTimestamp = KeQueryInterruptTime();
     Element->DeviceExtension = DeviceExtension;
     Element->Srb = Srb;
     Element->StartingLbn = StartingLbn;

--- a/driver/userspace.c
+++ b/driver/userspace.c
@@ -113,8 +113,8 @@ WnbdDeviceMonitorThread(_In_ PVOID Context)
     WNBD_LOG_INFO("Finished waiting for pending device requests: %s.",
                   Device->Properties.InstanceName);
 
-    DrainDeviceQueue(Device, FALSE);
-    DrainDeviceQueue(Device, TRUE);
+    DrainDeviceQueue(Device, FALSE, FALSE);
+    DrainDeviceQueue(Device, TRUE, FALSE);
 
     // After acquiring the device spinlock, we should return as quickly as possible.
     KIRQL Irql = { 0 };

--- a/driver/util.h
+++ b/driver/util.h
@@ -12,7 +12,8 @@
 
 VOID
 DrainDeviceQueue(_In_ PWNBD_DISK_DEVICE Device,
-                 _In_ BOOLEAN SubmittedRequests);
+                 _In_ BOOLEAN SubmittedRequests,
+                 _In_ BOOLEAN CheckStaleConn);
 
 VOID
 CompleteRequest(_In_ PWNBD_DISK_DEVICE Device,

--- a/driver/wnbd_dispatch.c
+++ b/driver/wnbd_dispatch.c
@@ -251,6 +251,8 @@ NTSTATUS WnbdDispatchRequest(
         ExInterlockedInsertTailList(
             &Device->SubmittedReqListHead,
             &Element->Link, &Device->SubmittedReqListLock);
+
+        Device->Stats.LastSubmittedReqTimestamp = KeQueryInterruptTime();
         InterlockedIncrement64(&Device->Stats.TotalSubmittedIORequests);
         InterlockedIncrement64(&Device->Stats.PendingSubmittedIORequests);
         InterlockedDecrement64(&Device->Stats.UnsubmittedIORequests);
@@ -390,6 +392,7 @@ NTSTATUS WnbdHandleResponse(
     }
 
 Exit:
+    Device->Stats.LastReplyTimestamp = KeQueryInterruptTime();
     InterlockedIncrement64(&Device->Stats.TotalReceivedIOReplies);
     InterlockedDecrement64(&Device->Stats.PendingSubmittedIORequests);
 

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -210,7 +210,14 @@ typedef struct
     // Soft device removals will wait for outstanding IO
     // requests.
     INT64 OutstandingIOCount;
-    INT64 Reserved[15];
+    // The following timestamps are retrieved using KeQueryInterruptTime.
+    // We aren't using QPC since 15ms precision is enough in our case
+    // and we want to avoid the potential overhead that may occur if
+    // QPC can't leverage TSC.
+    UINT64 LastReceivedReqTimestamp;
+    UINT64 LastSubmittedReqTimestamp;
+    UINT64 LastReplyTimestamp;
+    INT64 Reserved[12];
 } WNBD_DRV_STATS, *PWNBD_DRV_STATS;
 WNBD_ASSERT_SZ_EQ(WNBD_DRV_STATS, 192);
 

--- a/include/wnbd_ioctl.h
+++ b/include/wnbd_ioctl.h
@@ -62,6 +62,9 @@ static const GUID WNBD_GUID = {
 #define WNBD_ABS_MAX_IO_REQ_PER_ADAPTER 1024 * 128
 #define WNBD_ABS_MAX_IO_REQ_PER_LUN 1024
 
+#define WNBD_DEFAULT_STALE_REQ_TIMEOUT_MS 15000
+#define WNBD_DEFAULT_STALE_CONN_TIMEOUT_MS 60000
+
 // Only used for NBD connections, in which case the block size is optional.
 #define WNBD_DEFAULT_BLOCK_SIZE 512
 

--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -191,16 +191,24 @@ DWORD CmdStats(string InstanceName)
         return Status;
     }
 
+    int64_t TimeNow = (int64_t) GetTickCount64();
+
     cout << "Disk stats" << endl << left
-         << setw(30) << "TotalReceivedIORequests" << " : " <<  Stats.TotalReceivedIORequests << endl
-         << setw(30) << "TotalSubmittedIORequests" << " : " <<  Stats.TotalSubmittedIORequests << endl
-         << setw(30) << "TotalReceivedIOReplies" << " : " <<  Stats.TotalReceivedIOReplies << endl
-         << setw(30) << "UnsubmittedIORequests" << " : " <<  Stats.UnsubmittedIORequests << endl
-         << setw(30) << "PendingSubmittedIORequests" << " : " <<  Stats.PendingSubmittedIORequests << endl
-         << setw(30) << "AbortedSubmittedIORequests" << " : " <<  Stats.AbortedSubmittedIORequests << endl
-         << setw(30) << "AbortedUnsubmittedIORequests" << " : " <<  Stats.AbortedUnsubmittedIORequests << endl
-         << setw(30) << "CompletedAbortedIORequests" << " : " <<  Stats.CompletedAbortedIORequests << endl
-         << setw(30) << "OutstandingIOCount" << " : " <<  Stats.OutstandingIOCount << endl
+         << setw(30) << "TotalReceivedIORequests" << " : " << Stats.TotalReceivedIORequests << endl
+         << setw(30) << "TotalSubmittedIORequests" << " : " << Stats.TotalSubmittedIORequests << endl
+         << setw(30) << "TotalReceivedIOReplies" << " : " << Stats.TotalReceivedIOReplies << endl
+         << setw(30) << "UnsubmittedIORequests" << " : " << Stats.UnsubmittedIORequests << endl
+         << setw(30) << "PendingSubmittedIORequests" << " : " << Stats.PendingSubmittedIORequests << endl
+         << setw(30) << "AbortedSubmittedIORequests" << " : " << Stats.AbortedSubmittedIORequests << endl
+         << setw(30) << "AbortedUnsubmittedIORequests" << " : " << Stats.AbortedUnsubmittedIORequests << endl
+         << setw(30) << "CompletedAbortedIORequests" << " : " << Stats.CompletedAbortedIORequests << endl
+         << setw(30) << "OutstandingIOCount" << " : " << Stats.OutstandingIOCount << endl
+         << setw(30) << "TimeSinceLastReceivedReqMs" << " : "
+                     << (TimeNow - Stats.LastReceivedReqTimestamp / 10000) << endl
+         << setw(30) << "TimeSinceLastSubmittedReqMs" << " : "
+                     << (TimeNow - Stats.LastSubmittedReqTimestamp / 10000) << endl
+         << setw(30) << "TimeSinceLastReplyMs" << " : "
+                     << (TimeNow - Stats.LastReplyTimestamp / 10000) << endl
          << endl;
     return Status;
 }
@@ -260,25 +268,25 @@ DWORD CmdShow(string InstanceName)
     }
 
     cout << "Connection info" << endl << left
-         << setw(25) << "InstanceName" << " : " <<  ConnInfo.Properties.InstanceName << endl
-         << setw(25) << "SerialNumber" << " : " <<  ConnInfo.Properties.SerialNumber << endl
-         << setw(25) << "Owner" << " : " <<  ConnInfo.Properties.Owner << endl
-         << setw(25) << "ReadOnly" << " : " <<  ConnInfo.Properties.Flags.ReadOnly << endl
-         << setw(25) << "FlushSupported" << " : " <<  ConnInfo.Properties.Flags.FlushSupported << endl
-         << setw(25) << "FUASupported" << " : " <<  ConnInfo.Properties.Flags.FUASupported << endl
-         << setw(25) << "UnmapSupported" << " : " <<  ConnInfo.Properties.Flags.UnmapSupported << endl
+         << setw(25) << "InstanceName" << " : " << ConnInfo.Properties.InstanceName << endl
+         << setw(25) << "SerialNumber" << " : " << ConnInfo.Properties.SerialNumber << endl
+         << setw(25) << "Owner" << " : " << ConnInfo.Properties.Owner << endl
+         << setw(25) << "ReadOnly" << " : " << ConnInfo.Properties.Flags.ReadOnly << endl
+         << setw(25) << "FlushSupported" << " : " << ConnInfo.Properties.Flags.FlushSupported << endl
+         << setw(25) << "FUASupported" << " : " << ConnInfo.Properties.Flags.FUASupported << endl
+         << setw(25) << "UnmapSupported" << " : " << ConnInfo.Properties.Flags.UnmapSupported << endl
          << setw(25) << "UnmapAnchorSupported " << " : "
                      << ConnInfo.Properties.Flags.UnmapAnchorSupported << endl
-         << setw(25) << "UseUserspaceNbd" << " : " <<  ConnInfo.Properties.Flags.UseUserspaceNbd << endl
-         << setw(25) << "BlockCount" << " : " <<  ConnInfo.Properties.BlockCount << endl
-         << setw(25) << "BlockSize" << " : " <<  ConnInfo.Properties.BlockSize << endl
-         << setw(25) << "MaxUnmapDescCount" << " : " <<  ConnInfo.Properties.MaxUnmapDescCount << endl
-         << setw(25) << "Pid" << " : " <<  ConnInfo.Properties.Pid << endl
-         << setw(25) << "DiskNumber" << " : " <<  ConnInfo.DiskNumber << endl
-         << setw(25) << "PNPDeviceID" << " : " <<  to_string(wstring(ConnInfo.PNPDeviceID)) << endl
-         << setw(25) << "BusNumber" << " : " <<  ConnInfo.BusNumber << endl
-         << setw(25) << "TargetId" << " : " <<  ConnInfo.TargetId << endl
-         << setw(25) << "Lun" << " : " <<  ConnInfo.Lun << endl
+         << setw(25) << "UseUserspaceNbd" << " : " << ConnInfo.Properties.Flags.UseUserspaceNbd << endl
+         << setw(25) << "BlockCount" << " : " << ConnInfo.Properties.BlockCount << endl
+         << setw(25) << "BlockSize" << " : " << ConnInfo.Properties.BlockSize << endl
+         << setw(25) << "MaxUnmapDescCount" << " : " << ConnInfo.Properties.MaxUnmapDescCount << endl
+         << setw(25) << "Pid" << " : " << ConnInfo.Properties.Pid << endl
+         << setw(25) << "DiskNumber" << " : " << ConnInfo.DiskNumber << endl
+         << setw(25) << "PNPDeviceID" << " : " << to_string(wstring(ConnInfo.PNPDeviceID)) << endl
+         << setw(25) << "BusNumber" << " : " << ConnInfo.BusNumber << endl
+         << setw(25) << "TargetId" << " : " << ConnInfo.TargetId << endl
+         << setw(25) << "Lun" << " : " << ConnInfo.Lun << endl
          // For consistency, we're using the same naming as the wnbd settings for IO limits.
          << setw(25) << "MaxIOReqPerLun" << " : " << LunMaxIoCount << endl
          << setw(25) << "MaxIOReqPerAdapter" << " : " << AdapterMaxIoCount << endl


### PR DESCRIPTION
Storport resets the lun after hitting request timeouts. However,
it never actually removes the disk. Having a stale disk can be
troublesome, leading to an unresponsive host in certain situations
(e.g. cache deadlocks, hanging persistent reservation
requests, etc).

For this reason, we'll detect stale connections and disconnect
the disk. This feature along with the timeouts are configurable.
By default, we'll consider a connection to be stale if at least one
request older than 15s got aborted and if no IO reply was received
in the last minute.

At the same time, we'll include the following timestamps in the
``wnbd-client.exe stats`` output:

* last received request
* last submitted request
* last received reply

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>