### PR TITLE
client: properly handle negative time counters

### DIFF
--- a/wnbd-client/cmd.cpp
+++ b/wnbd-client/cmd.cpp
@@ -204,11 +204,11 @@ DWORD CmdStats(string InstanceName)
          << setw(30) << "CompletedAbortedIORequests" << " : " << Stats.CompletedAbortedIORequests << endl
          << setw(30) << "OutstandingIOCount" << " : " << Stats.OutstandingIOCount << endl
          << setw(30) << "TimeSinceLastReceivedReqMs" << " : "
-                     << (TimeNow - Stats.LastReceivedReqTimestamp / 10000) << endl
+                     << max(0, (int64_t) (TimeNow - Stats.LastReceivedReqTimestamp / 10000)) << endl
          << setw(30) << "TimeSinceLastSubmittedReqMs" << " : "
-                     << (TimeNow - Stats.LastSubmittedReqTimestamp / 10000) << endl
+                     << max(0, (int64_t) (TimeNow - Stats.LastSubmittedReqTimestamp / 10000)) << endl
          << setw(30) << "TimeSinceLastReplyMs" << " : "
-                     << (TimeNow - Stats.LastReplyTimestamp / 10000) << endl
+                     << max(0, (int64_t) (TimeNow - Stats.LastReplyTimestamp / 10000)) << endl
          << endl;
     return Status;
 }


### PR DESCRIPTION
"wnbd-client stats" now reports a few time counters, such as "TimeSinceLastReceivedReqMs". Those counters have a ~15ms accuracy, so for really short intervals we can end up with a negative value when comparing with the current timestamp:

```
  TimeSinceLastReceivedReqMs     : 18446744073709551604
  TimeSinceLastSubmittedReqMs    : 18446744073709551604
  TimeSinceLastReplyMs           : 18446744073709551604
```

This patch will translate such intervals to 0.