### PR TITLE
libwnbd: add WnbdPollDiskNumber function

### DIFF
--- a/include/wnbd.h
+++ b/include/wnbd.h
@@ -186,6 +186,16 @@ DWORD WnbdSetDiskSize(
 // Cleanup the PWNBD_DISK structure. This should be called after stopping
 // the IO dispatchers.
 VOID WnbdClose(PWNBD_DISK Disk);
+// Waits for the disk to become available and returns the associated disk
+// number. Returns ERROR_TIMEOUT if the timeout is exceeded and zero if the
+// operation succeeded.
+DWORD WnbdPollDiskNumber(
+    const char* InstanceName,
+    BOOLEAN ExpectMapped,
+    BOOLEAN TryOpen,
+    DWORD TimeoutMs,
+    DWORD RetryIntervalMs,
+    PDWORD DiskNumber);
 
 DWORD WnbdList(
     PWNBD_CONNECTION_LIST ConnectionList,

--- a/libwnbd/libwnbd.def
+++ b/libwnbd/libwnbd.def
@@ -7,6 +7,7 @@ EXPORTS
     WnbdRemoveEx
     WnbdSetDiskSize
     WnbdClose
+    WnbdPollDiskNumber
     WnbdList
     WnbdShow
     WnbdGetUserspaceStats


### PR DESCRIPTION
After mapping a WNBD disk, we're informimg the Storport driver that the bus changed, expecting it to rescan the bus and then expose the disk. This happens asynchronously and usually takes a few milliseconds, however it can take a few seconds under huge load.

WNBD clients need to wait for the disk to become available before being able to use it. For convenience, we'll add a function that performs the necessary polling, waiting for a disk number to be assigned. It optionally opens the disk, ensuring that it's ready.