### PR TITLE
wnbd-client: use utf-8

### DIFF
--- a/wnbd-client/code_page.manifest
+++ b/wnbd-client/code_page.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/wnbd-client/main.cpp
+++ b/wnbd-client/main.cpp
@@ -8,5 +8,6 @@
 
 int main(int argc, const char** argv)
 {
+    SetConsoleOutputCP(CP_UTF8);
     return Client().execute(argc, argv);
 }

--- a/wnbd-client/wnbd-client.vcxproj
+++ b/wnbd-client/wnbd-client.vcxproj
@@ -152,6 +152,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="code_page.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\deps\boost.1.72.0.0\build\boost.targets')" />


### PR DESCRIPTION
wnbd-client doesn't currently accept unicode CLI arguments.

We'll use utf-8 instead of utf-16 for the following reasons:

* better interoperability
* the wnbd API is mostly using char* instead of wchar*
* we already require Windows >= 10.0.17134.0, so we're free to use the utf-8 locale